### PR TITLE
Update download links to 20.2

### DIFF
--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -1,8 +1,8 @@
 const VERSIONS_ENDPOINT = 'https://maven.neoforged.net/api/maven/versions/releases/'
-const FORGE_GAV = 'net/neoforged/forge'
+const FORGE_GAV = 'net/neoforged/neoforge'
 const LATEST_ENDPOINT = 'https://maven.neoforged.net/api/maven/latest/version/releases/'
-const DOWNLOAD_URL = 'https://maven.neoforged.net/net/neoforged/forge'
-//https://maven.neoforged.net/api/maven/latest/version/releases/net%2Fneoforged%2Fforge?filter=1.20.1
+const DOWNLOAD_URL = 'https://maven.neoforged.net/releases/net/neoforged/neoforge'
+//https://maven.neoforged.net/api/maven/latest/version/releases/net%2Fneoforged%2Fneoforge?filter=20.2
 async function loadLatestVersions(minecraftVersions) {
     for (const mcVersion of minecraftVersions) {
         let currentMcVersionUrl = new URL(LATEST_ENDPOINT + encodeURIComponent(FORGE_GAV) + '?filter=' + encodeURIComponent(mcVersion));
@@ -22,8 +22,8 @@ async function loadLatestVersions(minecraftVersions) {
         if (versionJson) {
             const {version} = versionJson;
             
-            const installerUrl = `${DOWNLOAD_URL}/${encodeURIComponent(version)}/forge-${encodeURIComponent(version)}-installer.jar`;
-            const changelogUrl = `${DOWNLOAD_URL}/${encodeURIComponent(version)}/forge-${encodeURIComponent(version)}-changelog.txt`;
+            const installerUrl = `${DOWNLOAD_URL}/${encodeURIComponent(version)}/neoforge-${encodeURIComponent(version)}-installer.jar`;
+            const changelogUrl = `${DOWNLOAD_URL}/${encodeURIComponent(version)}/neoforge-${encodeURIComponent(version)}-changelog.txt`;
             document.querySelector("#filelist").innerHTML = `
                 <div class="fileinfo__header">NeoForge ${version}</div>
                 <div class="fileinfo__body">

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,7 +12,7 @@ description: |
 # NeoForge installer files
 You can find a direct link to our latest installer file below.
 
-{{< files "1.20.1" >}}
+{{< files "20.2" >}}
 
 Note: this file is still called forge because we're trying to maintain compatibility with launchers,
 assuming they don't hardcode things too much.


### PR DESCRIPTION
**Note, this is a temporary solution; long term it would be good to have a real downloads page with multiple versions and stuff.**

This updates the script used to detect versions to poke the right endpoints for the 20.2 versions - long term we'll want a real download page solution (and I can think of a few sensible approaches) but I figured this would do for now

------------------
Preview URL: https://pr-11.neoforged-website-previews.pages.dev