### PR TITLE
Remove 1.20.1 NeoForge link 

### DIFF
--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -8,37 +8,16 @@ const DOWNLOAD_URL = 'https://maven.neoforged.net/releases'
 // To filter a specific MC version: https://maven.neoforged.net/api/maven/latest/version/releases/net/neoforged/neoforge?filter=20.4
 async function loadLatestVersions(minecraftVersions) {
     for (const mcVersion of minecraftVersions) {
-        let gav;
-        let fn;
+        let gav = FORGE_GAV;
+        let fn = "neoforge";
         let mcvers;
-        let dropDown_VAL;
-        let badges_beta;
-        let badges_new;
-        let badges_legacy;
-        if (mcVersion.startsWith("1.20.1")) {
-            gav = LEGACY_GAV;
-            fn = "forge";
-            mcvers = "1.20.1";
-            badges_new = "";
-            badges_legacy = `<font class="badges badges_legacy">LEGACY</font>`;
-            badges_beta = "";
-            dropDown_VAL = "";
-        } else {
-            gav = FORGE_GAV;
-            fn = "neoforge";
-            badges_beta = "";
-            badges_new = `<font class="badges badges_new">NEW</font>`;
-            badges_legacy = "";
-            dropDown_VAL = ` open="open"`;
-        }
+        let dropDown_VAL = ` open="open"`;
+        let badges_beta = "";
+        let badges_new = "";
+        let badges_legacy = "";
 
-        let currentMcVersionUrl;
+        let currentMcVersionUrl = new URL(LATEST_ENDPOINT + encodeURIComponent(gav));
         let versionJson;
-        if (mcvers == "1.20.1") {
-            currentMcVersionUrl = new URL(LATEST_ENDPOINT + encodeURIComponent(gav) + '?filter=' + encodeURIComponent(mcVersion));
-        } else {
-            currentMcVersionUrl = new URL(LATEST_ENDPOINT + encodeURIComponent(gav));
-        }
 
         try {
             const response = await fetch(currentMcVersionUrl);

--- a/content/_index.md
+++ b/content/_index.md
@@ -13,7 +13,6 @@ description: |
 You can find a direct link to our latest installer files below.
 
 {{< files "latest" >}}
-{{< files "1.20.1" >}}
 {{< versions >}}
 
 # Using NeoForge for mod development


### PR DESCRIPTION
We keep recommending Forge to players and modders to use for 1.20.1. Having the NeoForge download link for 1.20.1 has been causing nothing but confusion and really isn't serving any purpose. Heck, you can even find 1.20.1 here in the project version dropdown!
https://projects.neoforged.net/neoforged/neoforge

So lets remove this last download link but keep 1.20.1 NeoForge on the maven to prevent breaking any system that is pulling form maven. Just no user facing links for 1.20.1


------------------
Preview URL: https://pr-52.neoforged-website-previews.pages.dev