### PR TITLE
Update Display Errors to refer to the correct config key for NeoForge

### DIFF
--- a/content/meta/displayerrors.md
+++ b/content/meta/displayerrors.md
@@ -15,7 +15,7 @@ There's several steps we can take to try and get you running with Minecraft and 
 This contains a lot of useful information, including steps like updating your graphics drivers, 
 and minimum requirements to play the game. Remember, if you can't run the vanilla game using the vanilla launcher, we can't help you run NeoForge.
 2. If you can run the vanilla game, but can't run Forge, you may need to turn off the fancy early loading display.
-To do so, find your minecraft game folder, and edit the config/fml.toml file. Change the "splashscreen" line from `splashscreen=true` to `splashscreen=false`
+To do so, find your minecraft game folder, and edit the config/fml.toml file. Change the "earlyWindowControl" line from `earlyWindowControl=true` to `earlyWindowControl=false`
 Make sure you come discuss your problem on the [NeoForge discord](https://discord.neoforged.net), because this shouldn't be necessary.
 
 


### PR DESCRIPTION
The text currently refers to a `splashscreen` key that hasn't been in use since *very early* Forge 1.20.1 builds (47.0.4, Neo forked at 47.1.3), as such all NeoForge builds/installs make use of the `earlyWindowControl` key instead.

------------------
Preview URL: https://pr-70.neoforged-website-previews.pages.dev