### PR TITLE
Redesign the version downloader on main page

### DIFF
--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -12,11 +12,9 @@ function setLinks(neoforgeVersion) {
 
     const mainMinecraftDropdown = document.getElementById("minecraft-versions");
     mainMinecraftDropdown.innerHTML = `${selectedMinecraftVersion}<span style="float: inline-end;">▼</span>`;
-    mainMinecraftDropdown.value = selectedMinecraftVersion;
 
     const mainNeoforgeDropdown = document.getElementById("neoforge-versions");
     mainNeoforgeDropdown.innerHTML = `${neoforgeVersion}<span style="float: inline-end;">▼</span>`;
-    mainNeoforgeDropdown.value = neoforgeVersion;
 
     const allNeoforgeVersionDropdown = document.getElementById("all-neoforge-versions");
     const latestNeoforgeVersion = allNeoforgeVersionDropdown.options[0].value;
@@ -40,9 +38,8 @@ function minecraftValueChanged(optionElement, optionClass) {
 
     // Unselect previous option in dropdown
     const allRelatedOptions = document.querySelectorAll(`.${optionClass}`);
-    allRelatedOptions.forEach((option) => { option.classList.remove("selectedOption"); option.setAttribute('aria-selected', 'false'); });
+    allRelatedOptions.forEach((option) => option.classList.remove("selectedOption"));
     optionElement.classList.add("selectedOption");
-    optionElement.setAttribute('aria-selected', 'true');
 
     const allNeoforgeVersionOptions = document.querySelectorAll("#all-neoforge-versions option");
     const allNeoforgeVersions = [...allNeoforgeVersionOptions].map((option) => option.value);
@@ -62,11 +59,11 @@ function minecraftValueChanged(optionElement, optionClass) {
 function neoforgeValueChanged(optionElement, optionClass) {
     // Unselect previous option in dropdown
     const allRelatedOptions = document.querySelectorAll(`.${optionClass}`);
-    allRelatedOptions.forEach((option) => { option.classList.remove("selectedOption"); option.setAttribute('aria-selected', 'false'); });
+    allRelatedOptions.forEach((option) => option.classList.remove("selectedOption"));
     optionElement.classList.add("selectedOption");
-    optionElement.setAttribute('aria-selected', 'true');
 
     setLinks(optionElement.dataset.neoforgeVersion);
+    
 }
 
 async function loadVersions() {
@@ -172,164 +169,80 @@ async function loadVersions() {
     }
 }
 
-let openedDropdownId = undefined;
-let currentOptionIndex = 0;
 
 /* Modified custom dropdown element from: https://www.w3schools.com/howto/howto_js_dropdown.asp */
 /* When the user clicks on the button, toggle between hiding and showing the dropdown content */
 function showDropdown(currentElement) {
-    // Hide all dropdowns as we will re-open the currently selected dropdown option
-    closeAllDropdowns();
-
-    // Keep clicked dropdown closed if it was already opened before. Creates toggle behavior of show/hide when clicking the selected preview element
-    if (openedDropdownId == currentElement.id) {
-        openedDropdownId = undefined;
-        return;
-    }
-
-    // Display current dropdown's options
-    currentElement.setAttribute('aria-expanded', true);
     document.getElementById(currentElement.dataset.dropdownContentId).classList.toggle("show");
 
-    // Move user focus to selected dropdown element (Hoping this is better for keyboard users)
-    const selectedDropdown = document.querySelector(`#${currentElement.dataset.dropdownContentId} .selectedOption`);
-    selectedDropdown.focus();
-
-    currentOptionIndex = Number(selectedDropdown.dataset.index);
-    openedDropdownId = currentElement.id;
-}
-
-function closeAllDropdowns() {
-    // Mark all dropdown as closed
-    const otherDropdowns = document.querySelectorAll(`.dropbtn`);
-    for (let i = 0; i < otherDropdowns.length; i++) {
-        const otherDropdown = otherDropdowns[i];
-        otherDropdown.setAttribute('aria-expanded', false);
-    }
+    // Move user focus to first dropdown element (Hoping this is better for keyboard users)
+    const firstOwningDropdown = document.querySelector(`#${currentElement.dataset.dropdownContentId} .selectedOption`);
+    firstOwningDropdown.focus();
 
     // Close dropdown options of other dropdowns.
-    const otherDropdownDisplays = document.querySelectorAll(`.dropdown-content`);
-    for (let i = 0; i < otherDropdownDisplays.length; i++) {
-        const otherDropdownDisplay = otherDropdownDisplays[i];
-        if (otherDropdownDisplay.classList.contains('show')) {
-            otherDropdownDisplay.classList.remove('show');
+    const otherDropdowns = document.querySelectorAll(`.dropdown-content:not(#${currentElement.dataset.dropdownContentId})`);
+    for (let i = 0; i < otherDropdowns.length; i++) {
+        const openDropdown = otherDropdowns[i];
+        if (openDropdown.classList.contains('show')) {
+            openDropdown.classList.remove('show');
         }
     }
 }
 
-function closeDropdownOnOutsideClick(event) {
-  if (openedDropdownId && !event.target.matches('.dropbtn')) {
-    closeAllDropdowns();
-    openedDropdownId = undefined;
-  }
-}
-
-function handleKeyPress(event) {
-  if (!openedDropdownId) {
-    return
-  } 
-
-  if (event.key === 'Escape') {
-    closeAllDropdowns();
-    openedDropdownId = undefined;
-    event.preventDefault();
-  }
-  else if (event.key === 'ArrowDown') {
-    const currentDropdownMain = document.querySelector(`#${openedDropdownId}`);
-    const currentOpenedDropdown = document.querySelector(`#${currentDropdownMain.dataset.dropdownContentId}`);
-    const currentSelectedOption = document.querySelector(`#${currentOpenedDropdown.id} .selectedOption`);
-    if (currentOptionIndex < currentOpenedDropdown.children.length - 1) {
-        currentOptionIndex++;
-
-        const newSelectedOption = currentOpenedDropdown.children[currentOptionIndex];
-        newSelectedOption.setAttribute('aria-selected', 'true');
-        newSelectedOption.focus({ focusVisible: true });
-        newSelectedOption.classList.add("selectedOption");
-
-        currentSelectedOption.classList.remove("selectedOption");
-        currentSelectedOption.setAttribute('aria-selected', 'false');
-        event.preventDefault();
+// Close the dropdown menu if the user clicks outside of it
+window.onclick = function(event) {
+  if (!event.target.matches('.dropbtn')) {
+    const dropdowns = document.getElementsByClassName("dropdown-content");
+    for (let i = 0; i < dropdowns.length; i++) {
+      const openDropdown = dropdowns[i];
+      if (openDropdown.classList.contains('show')) {
+        openDropdown.classList.remove('show');
+      }
     }
   }
-  else if (event.key === 'ArrowUp') {
-    const currentDropdownMain = document.querySelector(`#${openedDropdownId}`);
-    const currentOpenedDropdown = document.querySelector(`#${currentDropdownMain.dataset.dropdownContentId}`);
-    const currentSelectedOption = document.querySelector(`#${currentOpenedDropdown.id} .selectedOption`);
-    if (currentOptionIndex > 0) {
-        currentOptionIndex--;
-        
-        const newSelectedOption = currentOpenedDropdown.children[currentOptionIndex];
-        newSelectedOption.setAttribute('aria-selected', 'true');
-        newSelectedOption.focus({ focusVisible: true });
-        newSelectedOption.classList.add("selectedOption");
-
-        currentSelectedOption.classList.remove("selectedOption");
-        currentSelectedOption.setAttribute('aria-selected', 'false');
-        event.preventDefault();
-    }
-  }
-}
-
-// Close the dropdown menu if the user clicks outside of it or clicks esc
-window.onclick = closeDropdownOnOutsideClick;
-window.onkeydown = handleKeyPress;
+} 
 
 // Helper to create the custom dropdowns quickly
 function createDropdownButton(name, id, optionClass, dataname, listOfButtonOptions, optionOnclickFunction) {
     const dropdownContainer = document.createElement('div');
     dropdownContainer.classList.add("dropdown");
 
-    const dropdownMainButton = document.createElement('button');;
-    dropdownMainButton.setAttribute("tab-index", "0");
+    const dropdownMainButton = document.createElement('button');
     dropdownMainButton.classList.add("dropbtn");
     dropdownMainButton.name = name;
     dropdownMainButton.id = id;
     dropdownMainButton.dataset.dropdownContentId = `${id}-dropdown-content`;
     dropdownMainButton.onclick = function(){showDropdown(this)};
-    dropdownMainButton.role = "combobox";
-    dropdownMainButton.setAttribute("aria-controls", "listbox");
-    dropdownMainButton.setAttribute("aria-haspopup", "listbox");
-    dropdownMainButton.setAttribute("aria-expanded", "true")
 
     // Creates the dropdown's options as buttons that when clicked, will set parent text and download links.
-    const dropdownContent = document.createElement('div');
-    dropdownContent.classList.add("dropdown-content");
-    dropdownContent.id = `${id}-dropdown-content`;
-    dropdownContent.role = "listbox";
-    populateDropdown(dropdownContent, optionClass, dataname, listOfButtonOptions, optionOnclickFunction);
+    const dropdownContentDiv = document.createElement('div');
+    dropdownContentDiv.classList.add("dropdown-content");
+    dropdownContentDiv.id = `${id}-dropdown-content`;
+    populateDropdown(dropdownContentDiv, optionClass, dataname, listOfButtonOptions, optionOnclickFunction);
 
     // Default to newest version displayed
     dropdownMainButton.innerHTML = `${listOfButtonOptions[0]}<span style="float: inline-end;">▼</span>`;
-    dropdownMainButton.value = listOfButtonOptions[0];
     
     dropdownContainer.appendChild(dropdownMainButton);
-    dropdownContainer.appendChild(dropdownContent);
+    dropdownContainer.appendChild(dropdownContentDiv);
     return dropdownContainer;
 }
 
 function populateDropdown(dropdownContentDiv, optionClass, dataname, listOfButtonOptions, optionOnclickFunction) {
     let firstOption = true;
-    let index = 0;
     listOfButtonOptions.forEach(function(optionValue) {
         const optionButton = document.createElement('button');
         optionButton.classList.add(optionClass);
         optionButton.setAttribute(`data-${dataname}`, optionValue);
-        optionButton.setAttribute(`data-index`, index);
         optionButton.onclick = function(){optionOnclickFunction(this, optionClass)};
         optionButton.innerHTML = optionValue;
-        optionButton.role = "option";
 
         if (firstOption) {
             // visually show as the selected option in dropdown
             optionButton.classList.add("selectedOption");
-            optionButton.setAttribute('aria-selected', 'true');
             firstOption = false;
-        }
-        else {
-            optionButton.setAttribute('aria-selected', 'false');
         }
 
         dropdownContentDiv.appendChild(optionButton);
-        index++;
     });
 }

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -71,7 +71,7 @@ async function loadVersions() {
                     </div>
                 </div>
                 <div class="download_row">
-                    <a id="installerlink" href="${latestInstallerUrl}"><span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-${latestMinecraftVersion}-${latestNeoForgeVersion}-installer.jar</span></span></a>
+                    <a id="installerlink" href="${latestInstallerUrl}"><span>Click Here to Download Installer</span></span></a>
                     <a id="changeloglink" href="${latestChangelogUrl}"><span>See changelog</span></a>
                 </div>
             </div>

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -56,7 +56,7 @@ async function loadLatestVersions(minecraftVersions) {
                 </details>
             `;
 
-            document.querySelector("projectlinkdetails").open = true;
+            document.querySelector("#projectlinkdetails").open = true;
         }
     }
 }

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -11,10 +11,10 @@ function setLinks(neoforgeVersion) {
     const selectedMinecraftVersion = "1." + neoforgeVersion.slice(0, 4);
 
     const mainMinecraftDropdown = document.getElementById("minecraft-versions");
-    mainMinecraftDropdown.innerHTML = `${selectedMinecraftVersion}<span style="float: inline-end;">⮟</span>`;
+    mainMinecraftDropdown.innerHTML = `${selectedMinecraftVersion}<span style="float: inline-end;">▼</span>`;
 
     const mainNeoforgeDropdown = document.getElementById("neoforge-versions");
-    mainNeoforgeDropdown.innerHTML = `${neoforgeVersion}<span style="float: inline-end;">⮟</span>`;
+    mainNeoforgeDropdown.innerHTML = `${neoforgeVersion}<span style="float: inline-end;">▼</span>`;
 
     const allNeoforgeVersionDropdown = document.getElementById("all-neoforge-versions");
     const latestNeoforgeVersion = allNeoforgeVersionDropdown.options[0].value;
@@ -221,7 +221,7 @@ function createDropdownButton(name, id, optionClass, dataname, listOfButtonOptio
     populateDropdown(dropdownContentDiv, optionClass, dataname, listOfButtonOptions, optionOnclickFunction);
 
     // Default to newest version displayed
-    dropdownMainButton.innerHTML = `${listOfButtonOptions[0]}<span style="float: inline-end;">⮟</span>`;
+    dropdownMainButton.innerHTML = `${listOfButtonOptions[0]}<span style="float: inline-end;">▼</span>`;
     
     dropdownContainer.appendChild(dropdownMainButton);
     dropdownContainer.appendChild(dropdownContentDiv);

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -56,17 +56,7 @@ async function loadLatestVersions(minecraftVersions) {
                 </details>
             `;
 
-            document.querySelector("projectlink").innerHTML = `
-                <div id="projectlink" class="fileinfo">
-                    <details${dropDown_VAL}>
-                        <summary class="fileinfo__header">For Other Versions</summary>
-                        <div class="fileinfo__body">
-                            <a href="https://projects.neoforged.net/neoforged/neoforge"><span class="fileinfo__icon"><i class="bi-file-earmark-arrow-down-fill" style="font-size: 2rem;"></i></span>
-                            <span class="fileinfo__content"><span>Click here to go to the version list!</span></span></a>
-                        </div>
-                    </details>
-                </div>
-            `;
+            document.querySelector("projectlinkdetails").open = true;
         }
     }
 }

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -7,20 +7,23 @@ const DOWNLOAD_URL = "https://maven.neoforged.net/releases"
 // For legacy version(s): https://maven.neoforged.net/api/maven/latest/version/releases/net/neoforged/forge?filter=1.20.1
 // To filter a specific MC version: https://maven.neoforged.net/api/maven/latest/version/releases/net/neoforged/neoforge?filter=20.4
 
+// Used for clearing the NeoForge version dropdown when a new Minecraft version is selected.
+// That way it can be populated with the new eligible NeoForge versions afterwards.
+function removeAllOptions(selectElement) {
+   let i;
+   let length = selectElement.options.length - 1
+   for(i = length; i >= 0; i--) {
+      selectElement.remove(i);
+   }
+}
+
 function setLinks(neoforgeVersion) {
+    const allNeoforgeVersionDropdown = document.getElementById("allneoforgeversions");
+    const latestNeoforgeVersion = allNeoforgeVersionDropdown.options[0].value;
     const selectedMinecraftVersion = "1." + neoforgeVersion.slice(0, 4);
 
-    const mainMinecraftDropdown = document.getElementById("minecraft-versions");
-    mainMinecraftDropdown.innerHTML = `${selectedMinecraftVersion}<span style="float: inline-end;">⮟</span>`;
-
-    const mainNeoforgeDropdown = document.getElementById("neoforge-versions");
-    mainNeoforgeDropdown.innerHTML = `${neoforgeVersion}<span style="float: inline-end;">⮟</span>`;
-
-    const allNeoforgeVersionDropdown = document.getElementById("all-neoforge-versions");
-    const latestNeoforgeVersion = allNeoforgeVersionDropdown.options[0].value;
-
     const installerUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(neoforgeVersion)}/neoforge-${encodeURIComponent(neoforgeVersion)}-installer.jar`;
-    const installerLink = document.getElementById("installer-link");
+    const installerLink = document.getElementById("installerlink");
     installerLink.href = installerUrl;
     installerLink.innerHTML = `<span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-${selectedMinecraftVersion}-${neoforgeVersion}-installer.jar</span></span>`;
     
@@ -30,45 +33,52 @@ function setLinks(neoforgeVersion) {
     if (neoforgeVersion != latestNeoforgeVersion) {
         changelogUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(neoforgeVersion)}/neoforge-${encodeURIComponent(neoforgeVersion)}-changelog.txt`;
     }
-    document.getElementById("changelog-link").href = changelogUrl;
+    document.getElementById("changeloglink").href = changelogUrl;
 }
 
-function minecraftValueChanged(optionElement, optionClass) {
-    let neoforgeVersionPrefixForCurrentMinecraft = optionElement.dataset.minecraftVersion.slice(2, 6);
+function minecraftValueChanged(selectedMinecraftVersion) {
+    var neoforgeVersionPrefixForCurrentMinecraft = selectedMinecraftVersion.slice(2, 6);
 
-    // Unselect previous option in dropdown
-    const allRelatedOptions = document.querySelectorAll(`.${optionClass}`);
-    allRelatedOptions.forEach((option) => option.classList.remove("selectedOption"));
-    optionElement.classList.add("selectedOption");
-
-    const allNeoforgeVersionOptions = document.querySelectorAll("#all-neoforge-versions option");
-    const allNeoforgeVersions = [...allNeoforgeVersionOptions].map((option) => option.value);
-    const neoforgeDropdown = document.getElementById("neoforge-versions-dropdown-content");
+    const allNeoforgeVersionDropdown = document.getElementById("allneoforgeversions");
+    const neoforgeDropdown = document.getElementById("neoforgeversions");
 
     // Nuke all options as we will re-add the new eligible versions
-    neoforgeDropdown.innerHTML = '';
+    removeAllOptions(neoforgeDropdown);
     
-    // Creates the dropdown of visible eligible NeoForge versions. Already in order of newest to oldest
-    const orderedNeoforgeVersionList = allNeoforgeVersions
-        .filter((neoVersion) => neoVersion.startsWith(neoforgeVersionPrefixForCurrentMinecraft)); // Only get the neoforge versions for current minecraft version
+    let newestNeoforgeForCurrentMinecraft = undefined;
+    for (var index = 0; index < allNeoforgeVersionDropdown.options.length; index++) {
+        const option = allNeoforgeVersionDropdown.options[index];
+        const neoforgeVersion = option.value;
 
-    populateDropdown(neoforgeDropdown, optionClass, "neoforge-version", orderedNeoforgeVersionList, neoforgeValueChanged);
-    setLinks(orderedNeoforgeVersionList[0]);
+        // Skip versions that are not eligible for current minecraft version
+        if (!neoforgeVersion.startsWith(neoforgeVersionPrefixForCurrentMinecraft)) {
+            continue;
+        }
+
+        var neoforgeVersionOption = document.createElement('option');
+        neoforgeVersionOption.value = neoforgeVersion;
+        neoforgeVersionOption.innerHTML = neoforgeVersion;
+
+        // Since allNeoforgeVersionDropdown is sorted by newest to oldest,
+        // we want to have the newest eligible NeoForge version selected by default when switching Minecraft versions. 
+        if (newestNeoforgeForCurrentMinecraft == undefined) {
+            newestNeoforgeForCurrentMinecraft = neoforgeVersion;
+            neoforgeVersionOption.selected = true;
+        }
+
+        neoforgeDropdown.appendChild(neoforgeVersionOption);
+    }
+
+    setLinks(newestNeoforgeForCurrentMinecraft);
 }
 
-function neoforgeValueChanged(optionElement, optionClass) {
-    // Unselect previous option in dropdown
-    const allRelatedOptions = document.querySelectorAll(`.${optionClass}`);
-    allRelatedOptions.forEach((option) => option.classList.remove("selectedOption"));
-    optionElement.classList.add("selectedOption");
-
-    setLinks(optionElement.dataset.neoforgeVersion);
-    
+function neoforgeValueChanged(selectedNeoforgeVersions) {
+    setLinks(selectedNeoforgeVersions);
 }
 
 async function loadVersions() {
     // Reminder, this endpoint will return all NeoForge versions with April Fools versions first, then oldest to newest versions afterwards.
-    const allVersionUrl = new URL(VERSIONS_ENDPOINT + encodeURIComponent(NEOFORGE_GAV));
+    let allVersionUrl = new URL(VERSIONS_ENDPOINT + encodeURIComponent(NEOFORGE_GAV));
     let neoforgeVersionsJson;
     try {
         const response = await fetch(allVersionUrl);
@@ -109,36 +119,45 @@ async function loadVersions() {
         document.getElementById("filelist").innerHTML = `
             <div class="fileinfo__body">
                 <div class="selection_row">
-                    <div class="selection_block" id="minecraft-versions-container">
-                        <label for="minecraft-versions">Minecraft Version:&nbsp;</label>
+                    <div class="selection_block" id="minecraftversionscontainer">
+                        <label for="minecraftversions">Minecraft Version:&nbsp;</label>
                     </div>
-                    <div class="selection_block" id="neoforge-versions-container">
-                        <label for="neoforge-versions">NeoForge Version:&nbsp;</label>
+                    <div class="selection_block"id="neoforgeversionscontainer">
+                        <label for="neoforgeversions">NeoForge Version:&nbsp;</label>
                     </div>
                 </div>
                 <div class="download_row">
-                    <a id="installer-link" href="${latestInstallerUrl}"><span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-${latestMinecraftVersion}-${latestNeoForgeVersion}-installer.jar</span></span></a>
-                    <a id="changelog-link" href="${latestChangelogUrl}"><span>See changelog</span></a>
+                    <a id="installerlink" href="${latestInstallerUrl}"><span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-${latestMinecraftVersion}-${latestNeoForgeVersion}-installer.jar</span></span></a>
+                    <a id="changeloglink" href="${latestChangelogUrl}"><span>See changelog</span></a>
                 </div>
             </div>
         `;
 
+        
         // Creates the select element for Minecraft versions
-        const minecraftVersionDropdown = createDropdownButton(
-            "Minecraft Versions", 
-            "minecraft-versions",
-            "minecraftVersionOption", 
-            "minecraft-version",
-            sortedMinecraftVersion,
-            minecraftValueChanged);
-        document.getElementById("minecraft-versions-container").appendChild(minecraftVersionDropdown);
+        var minecraftVersionSelect = document.createElement('select');
+        minecraftVersionSelect.name = 'Minecraft Versions';
+        minecraftVersionSelect.id = 'minecraftversions';
+        minecraftVersionSelect.onchange = function(){minecraftValueChanged(this.value);};
+        // Populate the select with the Minecraft versions. First option selected by default.
+        let firstOption = true;
+        sortedMinecraftVersion.forEach(function(minecraftVersion) {
+            var minecraftVersionOption = document.createElement('option');
+            minecraftVersionOption.value = minecraftVersion;
+            minecraftVersionOption.innerHTML = minecraftVersion;
+            if (firstOption) {
+                minecraftVersionOption.selected = true;
+                firstOption = false;
+            }
+            minecraftVersionSelect.appendChild(minecraftVersionOption);
+        });
+        document.getElementById("minecraftversionscontainer").appendChild(minecraftVersionSelect);
 
         // Creates the hidden select element for holding all neoforge versions.
-        // This is so we can use this as version storage to use to populate the dropdowns on Minecraft version change.
-        // We could not use a normal visible Select because Safari will show disabled/hidden options and browsers will show massive dropdowns of all options.
-        // A custom dropdown is used to have more control over the dropdowns and this hidden select is just for helping to cache version data on page quickly.
-        const allNeoforgeVersionSelect = document.createElement('select');
-        allNeoforgeVersionSelect.id = 'all-neoforge-versions';
+        // We need to do this because Safari will show hidden/disabled option elements.
+        // Thus this workaround by abusing a hidden select with all versions that we can use to populate the visible select with on Minecraft version change.
+        var allNeoforgeVersionSelect = document.createElement('select');
+        allNeoforgeVersionSelect.id = 'allneoforgeversions';
         allNeoforgeVersionSelect.hidden = true;
         allNeoforgeVersionSelect.disabled = true;
         allNeoforgeVersionSelect.style.display = 'none';
@@ -146,103 +165,37 @@ async function loadVersions() {
         // So iterating backwards will let us have newest be first option in dropdown.
         for (let index = neoforgeVersions.length - 1; index >= 0; index--) {   
             const neoforgeVersion = neoforgeVersions[index];
-            const neoforgeVersionOption = document.createElement('option');
+            var neoforgeVersionOption = document.createElement('option');
             neoforgeVersionOption.value = neoforgeVersion;
             neoforgeVersionOption.innerHTML = neoforgeVersion;
             allNeoforgeVersionSelect.appendChild(neoforgeVersionOption);
         }
         document.querySelector(".fileinfo__body").appendChild(allNeoforgeVersionSelect);
         
-        // Creates the dropdown of visible eligible NeoForge versions
-        const neoforgeVersionPrefixForCurrentMinecraft = latestNeoForgeVersion.slice(0, 4);
-        const orderedNeoforgeVersionList = neoforgeVersions
-            .filter((neoVersion) => neoVersion.startsWith(neoforgeVersionPrefixForCurrentMinecraft)) // Only get the neoforge versions for current minecraft version
-            .reverse(); // reverse as this function wants newest versions first.
-        const neoforgeVersionDropdown = createDropdownButton(
-            "NeoForge Versions", 
-            "neoforge-versions",
-            "neoforgeVersionOption", 
-            "neoforge-version",
-            orderedNeoforgeVersionList,
-            neoforgeValueChanged);
-        document.getElementById("neoforge-versions-container").appendChild(neoforgeVersionDropdown);
-    }
-}
-
-
-/* Modified custom dropdown element from: https://www.w3schools.com/howto/howto_js_dropdown.asp */
-/* When the user clicks on the button, toggle between hiding and showing the dropdown content */
-function showDropdown(currentElement) {
-    document.getElementById(currentElement.dataset.dropdownContentId).classList.toggle("show");
-
-    // Move user focus to first dropdown element (Hoping this is better for keyboard users)
-    const firstOwningDropdown = document.querySelector(`#${currentElement.dataset.dropdownContentId} .selectedOption`);
-    firstOwningDropdown.focus();
-
-    // Close dropdown options of other dropdowns.
-    const otherDropdowns = document.querySelectorAll(`.dropdown-content:not(#${currentElement.dataset.dropdownContentId})`);
-    for (let i = 0; i < otherDropdowns.length; i++) {
-        const openDropdown = otherDropdowns[i];
-        if (openDropdown.classList.contains('show')) {
-            openDropdown.classList.remove('show');
+        // Creates the select element for visible eligible NeoForge versions
+        var neoforgeVersionSelect = document.createElement('select');
+        neoforgeVersionSelect.name = 'NeoForge Versions';
+        neoforgeVersionSelect.id = 'neoforgeversions';
+        neoforgeVersionSelect.onchange = function(){neoforgeValueChanged(this.value);};
+        // Use the current Minecraft version to know which NeoForge versions are eligible for selection.
+        var neoforgeVersionPrefixForCurrentMinecraft = latestNeoForgeVersion.slice(0, 4);
+        // Versions url always gives list of versions from oldest to newest (exception of april fools versions which we already filtered)
+        // So iterating backwards will let us have newest be first option in dropdown.
+        firstOption = true;
+        for (let index = neoforgeVersions.length - 1; index >= 0; index--) {   
+            const neoforgeVersion = neoforgeVersions[index];
+             // Only get the neoforge versions for current minecraft version
+            if (neoforgeVersion.startsWith(neoforgeVersionPrefixForCurrentMinecraft)) {
+                var neoforgeVersionOption = document.createElement('option');
+                neoforgeVersionOption.value = neoforgeVersion;
+                neoforgeVersionOption.innerHTML = neoforgeVersion;
+                if (firstOption) {
+                    neoforgeVersionOption.selected = true;
+                    firstOption = false;
+                }
+                neoforgeVersionSelect.appendChild(neoforgeVersionOption);
+            }
         }
+        document.getElementById("neoforgeversionscontainer").appendChild(neoforgeVersionSelect);
     }
-}
-
-// Close the dropdown menu if the user clicks outside of it
-window.onclick = function(event) {
-  if (!event.target.matches('.dropbtn')) {
-    const dropdowns = document.getElementsByClassName("dropdown-content");
-    for (let i = 0; i < dropdowns.length; i++) {
-      const openDropdown = dropdowns[i];
-      if (openDropdown.classList.contains('show')) {
-        openDropdown.classList.remove('show');
-      }
-    }
-  }
-} 
-
-// Helper to create the custom dropdowns quickly
-function createDropdownButton(name, id, optionClass, dataname, listOfButtonOptions, optionOnclickFunction) {
-    const dropdownContainer = document.createElement('div');
-    dropdownContainer.classList.add("dropdown");
-
-    const dropdownMainButton = document.createElement('button');
-    dropdownMainButton.classList.add("dropbtn");
-    dropdownMainButton.name = name;
-    dropdownMainButton.id = id;
-    dropdownMainButton.dataset.dropdownContentId = `${id}-dropdown-content`;
-    dropdownMainButton.onclick = function(){showDropdown(this)};
-
-    // Creates the dropdown's options as buttons that when clicked, will set parent text and download links.
-    const dropdownContentDiv = document.createElement('div');
-    dropdownContentDiv.classList.add("dropdown-content");
-    dropdownContentDiv.id = `${id}-dropdown-content`;
-    populateDropdown(dropdownContentDiv, optionClass, dataname, listOfButtonOptions, optionOnclickFunction);
-
-    // Default to newest version displayed
-    dropdownMainButton.innerHTML = `${listOfButtonOptions[0]}<span style="float: inline-end;">⮟</span>`;
-    
-    dropdownContainer.appendChild(dropdownMainButton);
-    dropdownContainer.appendChild(dropdownContentDiv);
-    return dropdownContainer;
-}
-
-function populateDropdown(dropdownContentDiv, optionClass, dataname, listOfButtonOptions, optionOnclickFunction) {
-    let firstOption = true;
-    listOfButtonOptions.forEach(function(optionValue) {
-        const optionButton = document.createElement('button');
-        optionButton.classList.add(optionClass);
-        optionButton.setAttribute(`data-${dataname}`, optionValue);
-        optionButton.onclick = function(){optionOnclickFunction(this, optionClass)};
-        optionButton.innerHTML = optionValue;
-
-        if (firstOption) {
-            // visually show as the selected option in dropdown
-            optionButton.classList.add("selectedOption");
-            firstOption = false;
-        }
-
-        dropdownContentDiv.appendChild(optionButton);
-    });
 }

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -12,9 +12,11 @@ function setLinks(neoforgeVersion) {
 
     const mainMinecraftDropdown = document.getElementById("minecraft-versions");
     mainMinecraftDropdown.innerHTML = `${selectedMinecraftVersion}<span style="float: inline-end;">▼</span>`;
+    mainMinecraftDropdown.value = selectedMinecraftVersion;
 
     const mainNeoforgeDropdown = document.getElementById("neoforge-versions");
     mainNeoforgeDropdown.innerHTML = `${neoforgeVersion}<span style="float: inline-end;">▼</span>`;
+    mainNeoforgeDropdown.value = neoforgeVersion;
 
     const allNeoforgeVersionDropdown = document.getElementById("all-neoforge-versions");
     const latestNeoforgeVersion = allNeoforgeVersionDropdown.options[0].value;
@@ -38,8 +40,9 @@ function minecraftValueChanged(optionElement, optionClass) {
 
     // Unselect previous option in dropdown
     const allRelatedOptions = document.querySelectorAll(`.${optionClass}`);
-    allRelatedOptions.forEach((option) => option.classList.remove("selectedOption"));
+    allRelatedOptions.forEach((option) => { option.classList.remove("selectedOption"); option.setAttribute('aria-selected', 'false'); });
     optionElement.classList.add("selectedOption");
+    optionElement.setAttribute('aria-selected', 'true');
 
     const allNeoforgeVersionOptions = document.querySelectorAll("#all-neoforge-versions option");
     const allNeoforgeVersions = [...allNeoforgeVersionOptions].map((option) => option.value);
@@ -59,11 +62,11 @@ function minecraftValueChanged(optionElement, optionClass) {
 function neoforgeValueChanged(optionElement, optionClass) {
     // Unselect previous option in dropdown
     const allRelatedOptions = document.querySelectorAll(`.${optionClass}`);
-    allRelatedOptions.forEach((option) => option.classList.remove("selectedOption"));
+    allRelatedOptions.forEach((option) => { option.classList.remove("selectedOption"); option.setAttribute('aria-selected', 'false'); });
     optionElement.classList.add("selectedOption");
+    optionElement.setAttribute('aria-selected', 'true');
 
     setLinks(optionElement.dataset.neoforgeVersion);
-    
 }
 
 async function loadVersions() {
@@ -169,80 +172,164 @@ async function loadVersions() {
     }
 }
 
+let openedDropdownId = undefined;
+let currentOptionIndex = 0;
 
 /* Modified custom dropdown element from: https://www.w3schools.com/howto/howto_js_dropdown.asp */
 /* When the user clicks on the button, toggle between hiding and showing the dropdown content */
 function showDropdown(currentElement) {
+    // Hide all dropdowns as we will re-open the currently selected dropdown option
+    closeAllDropdowns();
+
+    // Keep clicked dropdown closed if it was already opened before. Creates toggle behavior of show/hide when clicking the selected preview element
+    if (openedDropdownId == currentElement.id) {
+        openedDropdownId = undefined;
+        return;
+    }
+
+    // Display current dropdown's options
+    currentElement.setAttribute('aria-expanded', true);
     document.getElementById(currentElement.dataset.dropdownContentId).classList.toggle("show");
 
-    // Move user focus to first dropdown element (Hoping this is better for keyboard users)
-    const firstOwningDropdown = document.querySelector(`#${currentElement.dataset.dropdownContentId} .selectedOption`);
-    firstOwningDropdown.focus();
+    // Move user focus to selected dropdown element (Hoping this is better for keyboard users)
+    const selectedDropdown = document.querySelector(`#${currentElement.dataset.dropdownContentId} .selectedOption`);
+    selectedDropdown.focus();
+
+    currentOptionIndex = Number(selectedDropdown.dataset.index);
+    openedDropdownId = currentElement.id;
+}
+
+function closeAllDropdowns() {
+    // Mark all dropdown as closed
+    const otherDropdowns = document.querySelectorAll(`.dropbtn`);
+    for (let i = 0; i < otherDropdowns.length; i++) {
+        const otherDropdown = otherDropdowns[i];
+        otherDropdown.setAttribute('aria-expanded', false);
+    }
 
     // Close dropdown options of other dropdowns.
-    const otherDropdowns = document.querySelectorAll(`.dropdown-content:not(#${currentElement.dataset.dropdownContentId})`);
-    for (let i = 0; i < otherDropdowns.length; i++) {
-        const openDropdown = otherDropdowns[i];
-        if (openDropdown.classList.contains('show')) {
-            openDropdown.classList.remove('show');
+    const otherDropdownDisplays = document.querySelectorAll(`.dropdown-content`);
+    for (let i = 0; i < otherDropdownDisplays.length; i++) {
+        const otherDropdownDisplay = otherDropdownDisplays[i];
+        if (otherDropdownDisplay.classList.contains('show')) {
+            otherDropdownDisplay.classList.remove('show');
         }
     }
 }
 
-// Close the dropdown menu if the user clicks outside of it
-window.onclick = function(event) {
-  if (!event.target.matches('.dropbtn')) {
-    const dropdowns = document.getElementsByClassName("dropdown-content");
-    for (let i = 0; i < dropdowns.length; i++) {
-      const openDropdown = dropdowns[i];
-      if (openDropdown.classList.contains('show')) {
-        openDropdown.classList.remove('show');
-      }
+function closeDropdownOnOutsideClick(event) {
+  if (openedDropdownId && !event.target.matches('.dropbtn')) {
+    closeAllDropdowns();
+    openedDropdownId = undefined;
+  }
+}
+
+function handleKeyPress(event) {
+  if (!openedDropdownId) {
+    return
+  } 
+
+  if (event.key === 'Escape') {
+    closeAllDropdowns();
+    openedDropdownId = undefined;
+    event.preventDefault();
+  }
+  else if (event.key === 'ArrowDown') {
+    const currentDropdownMain = document.querySelector(`#${openedDropdownId}`);
+    const currentOpenedDropdown = document.querySelector(`#${currentDropdownMain.dataset.dropdownContentId}`);
+    const currentSelectedOption = document.querySelector(`#${currentOpenedDropdown.id} .selectedOption`);
+    if (currentOptionIndex < currentOpenedDropdown.children.length - 1) {
+        currentOptionIndex++;
+
+        const newSelectedOption = currentOpenedDropdown.children[currentOptionIndex];
+        newSelectedOption.setAttribute('aria-selected', 'true');
+        newSelectedOption.focus({ focusVisible: true });
+        newSelectedOption.classList.add("selectedOption");
+
+        currentSelectedOption.classList.remove("selectedOption");
+        currentSelectedOption.setAttribute('aria-selected', 'false');
+        event.preventDefault();
     }
   }
-} 
+  else if (event.key === 'ArrowUp') {
+    const currentDropdownMain = document.querySelector(`#${openedDropdownId}`);
+    const currentOpenedDropdown = document.querySelector(`#${currentDropdownMain.dataset.dropdownContentId}`);
+    const currentSelectedOption = document.querySelector(`#${currentOpenedDropdown.id} .selectedOption`);
+    if (currentOptionIndex > 0) {
+        currentOptionIndex--;
+        
+        const newSelectedOption = currentOpenedDropdown.children[currentOptionIndex];
+        newSelectedOption.setAttribute('aria-selected', 'true');
+        newSelectedOption.focus({ focusVisible: true });
+        newSelectedOption.classList.add("selectedOption");
+
+        currentSelectedOption.classList.remove("selectedOption");
+        currentSelectedOption.setAttribute('aria-selected', 'false');
+        event.preventDefault();
+    }
+  }
+}
+
+// Close the dropdown menu if the user clicks outside of it or clicks esc
+window.onclick = closeDropdownOnOutsideClick;
+window.onkeydown = handleKeyPress;
 
 // Helper to create the custom dropdowns quickly
 function createDropdownButton(name, id, optionClass, dataname, listOfButtonOptions, optionOnclickFunction) {
     const dropdownContainer = document.createElement('div');
     dropdownContainer.classList.add("dropdown");
 
-    const dropdownMainButton = document.createElement('button');
+    const dropdownMainButton = document.createElement('button');;
+    dropdownMainButton.setAttribute("tab-index", "0");
     dropdownMainButton.classList.add("dropbtn");
     dropdownMainButton.name = name;
     dropdownMainButton.id = id;
     dropdownMainButton.dataset.dropdownContentId = `${id}-dropdown-content`;
     dropdownMainButton.onclick = function(){showDropdown(this)};
+    dropdownMainButton.role = "combobox";
+    dropdownMainButton.setAttribute("aria-controls", "listbox");
+    dropdownMainButton.setAttribute("aria-haspopup", "listbox");
+    dropdownMainButton.setAttribute("aria-expanded", "true")
 
     // Creates the dropdown's options as buttons that when clicked, will set parent text and download links.
-    const dropdownContentDiv = document.createElement('div');
-    dropdownContentDiv.classList.add("dropdown-content");
-    dropdownContentDiv.id = `${id}-dropdown-content`;
-    populateDropdown(dropdownContentDiv, optionClass, dataname, listOfButtonOptions, optionOnclickFunction);
+    const dropdownContent = document.createElement('div');
+    dropdownContent.classList.add("dropdown-content");
+    dropdownContent.id = `${id}-dropdown-content`;
+    dropdownContent.role = "listbox";
+    populateDropdown(dropdownContent, optionClass, dataname, listOfButtonOptions, optionOnclickFunction);
 
     // Default to newest version displayed
     dropdownMainButton.innerHTML = `${listOfButtonOptions[0]}<span style="float: inline-end;">▼</span>`;
+    dropdownMainButton.value = listOfButtonOptions[0];
     
     dropdownContainer.appendChild(dropdownMainButton);
-    dropdownContainer.appendChild(dropdownContentDiv);
+    dropdownContainer.appendChild(dropdownContent);
     return dropdownContainer;
 }
 
 function populateDropdown(dropdownContentDiv, optionClass, dataname, listOfButtonOptions, optionOnclickFunction) {
     let firstOption = true;
+    let index = 0;
     listOfButtonOptions.forEach(function(optionValue) {
         const optionButton = document.createElement('button');
         optionButton.classList.add(optionClass);
         optionButton.setAttribute(`data-${dataname}`, optionValue);
+        optionButton.setAttribute(`data-index`, index);
         optionButton.onclick = function(){optionOnclickFunction(this, optionClass)};
         optionButton.innerHTML = optionValue;
+        optionButton.role = "option";
 
         if (firstOption) {
             // visually show as the selected option in dropdown
             optionButton.classList.add("selectedOption");
+            optionButton.setAttribute('aria-selected', 'true');
             firstOption = false;
+        }
+        else {
+            optionButton.setAttribute('aria-selected', 'false');
         }
 
         dropdownContentDiv.appendChild(optionButton);
+        index++;
     });
 }

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -7,6 +7,8 @@ const DOWNLOAD_URL = "https://maven.neoforged.net/releases"
 // For legacy version(s): https://maven.neoforged.net/api/maven/latest/version/releases/net/neoforged/forge?filter=1.20.1
 // To filter a specific MC version: https://maven.neoforged.net/api/maven/latest/version/releases/net/neoforged/neoforge?filter=20.4
 
+// Used for clearing the NeoForge version dropdown when a new Minecraft version is selected.
+// That way it can be populated with the new eligible NeoForge versions afterwards.
 function removeAllOptions(selectElement) {
    let i;
    let length = selectElement.options.length - 1
@@ -21,15 +23,16 @@ function setLinks(neoforgeVersion) {
     const selectedMinecraftVersion = "1." + neoforgeVersion.slice(0, 4);
 
     const installerUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(neoforgeVersion)}/neoforge-${encodeURIComponent(neoforgeVersion)}-installer.jar`;
-    let changelogUrl = "/changelog";
-    if (neoforgeVersion != latestNeoforgeVersion) {
-        changelogUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(neoforgeVersion)}/neoforge-${encodeURIComponent(neoforgeVersion)}-changelog.txt`;
-    }
-
     const installerLink = document.getElementById("installerlink");
     installerLink.href = installerUrl;
     installerLink.innerHTML = `<span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-${selectedMinecraftVersion}-${neoforgeVersion}-installer.jar</span></span>`;
     
+    // The latest changelog exists on the website at /changelog so we use that when latest NeoForge is selected.
+    // Otherwise use the maven changelog text file link.
+    let changelogUrl = "/changelog";
+    if (neoforgeVersion != latestNeoforgeVersion) {
+        changelogUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(neoforgeVersion)}/neoforge-${encodeURIComponent(neoforgeVersion)}-changelog.txt`;
+    }
     document.getElementById("changeloglink").href = changelogUrl;
 }
 
@@ -55,6 +58,9 @@ function minecraftValueChanged(selectedMinecraftVersion) {
         var neoforgeVersionOption = document.createElement('option');
         neoforgeVersionOption.value = neoforgeVersion;
         neoforgeVersionOption.innerHTML = neoforgeVersion;
+
+        // Since allNeoforgeVersionDropdown is sorted by newest to oldest,
+        // we want to have the newest eligible NeoForge version selected by default when switching Minecraft versions. 
         if (newestNeoforgeForCurrentMinecraft == undefined) {
             newestNeoforgeForCurrentMinecraft = neoforgeVersion;
             neoforgeVersionOption.selected = true;
@@ -71,6 +77,7 @@ function neoforgeValueChanged(selectedNeoforgeVersions) {
 }
 
 async function loadVersions() {
+    // Reminder, this endpoint will return all NeoForge versions with April Fools versions first, then oldest to newest versions afterwards.
     let allVersionUrl = new URL(VERSIONS_ENDPOINT + encodeURIComponent(NEOFORGE_GAV));
     let neoforgeVersionsJson;
     try {
@@ -85,22 +92,30 @@ async function loadVersions() {
     }
 
     if (neoforgeVersionsJson) {
+        // Extract all NeoForge versions.
         const {versions} = neoforgeVersionsJson;
+
+        // Remove 0.25w14craftmine and other april fools versions
+        const neoforgeVersions = versions.filter((version) => !version.startsWith("0"));
+
+        // Using a set to prevent duplicate minecraft versions quickly as we extract the Minecraft versions from the NeoForge versions.
         const minecraftVersions = new Set([]);
-        for (const neoforgeVersion of versions) {
-            if (!neoforgeVersion.startsWith("0")) { // Skip 0.25w14craftmine and other april fools versions
-                minecraftVersions.add("1." + neoforgeVersion.slice(0, 4)); // Grab the Minecraft version from the NeoForge versions
-            }
+        for (const neoforgeVersion of neoforgeVersions) {
+            // The left 2 numbers for NeoForge versions is the last 2 numbers for Minecraft versions.
+            minecraftVersions.add("1." + neoforgeVersion.slice(0, 4)); 
         }
-        // Sorts the mc versions so newest is topmost. Done because we used a set to prevent duplicate minecraft versions quickly.
+
+        // Sorts the mc versions so newest is topmost. We can't sort a set so convert to array first.
         const sortedMinecraftVersion = Array.from(minecraftVersions).sort(function (a,b) {
             return b.localeCompare(a, undefined, { numeric: true, sensitivity: 'base' });
         });
         
-        const latestNeoForgeVersion = versions[versions.length - 1];
+        // Get newest NeoForge at end of the version list. Already future proofed to ignore April Fools version due to earlier filter.
+        const latestNeoForgeVersion = neoforgeVersions[neoforgeVersions.length - 1];
+        // Get newest NeoForge version at start of the sorted minecraft version list.
         const latestMinecraftVersion = sortedMinecraftVersion[0];
         const latestInstallerUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(latestNeoForgeVersion)}/neoforge-${encodeURIComponent(latestNeoForgeVersion)}-installer.jar`;
-        const latestChangelogUrl = "/changelog";
+        const latestChangelogUrl = "/changelog"; // Always is the latest version's changelog on site.
         document.getElementById("filelist").innerHTML = `
             <div class="fileinfo__body">
                 <div class="selection_row">
@@ -124,61 +139,59 @@ async function loadVersions() {
         minecraftVersionSelect.name = 'Minecraft Versions';
         minecraftVersionSelect.id = 'minecraftversions';
         minecraftVersionSelect.onchange = function(){minecraftValueChanged(this.value);};
+        // Populate the select with the Minecraft versions. First option selected by default.
         let firstOption = true;
         sortedMinecraftVersion.forEach(function(minecraftVersion) {
-
             var minecraftVersionOption = document.createElement('option');
             minecraftVersionOption.value = minecraftVersion;
             minecraftVersionOption.innerHTML = minecraftVersion;
             if (firstOption) {
                 minecraftVersionOption.selected = true;
+                firstOption = false;
             }
             minecraftVersionSelect.appendChild(minecraftVersionOption);
-
-            firstOption = false;
         });
         document.getElementById("minecraftversionscontainer").appendChild(minecraftVersionSelect);
 
         // Creates the hidden select element for holding all neoforge versions.
-        // We need to do this because Safari will show hidden/disabled option elements. Thus this workaround
+        // We need to do this because Safari will show hidden/disabled option elements.
+        // Thus this workaround by abusing a hidden select with all versions that we can use to populate the visible select with on Minecraft version change.
         var allNeoforgeVersionSelect = document.createElement('select');
         allNeoforgeVersionSelect.id = 'allneoforgeversions';
         allNeoforgeVersionSelect.hidden = true;
         allNeoforgeVersionSelect.disabled = true;
         allNeoforgeVersionSelect.style.display = 'none';
-        // Versions url always gives list of versions from oldest to newest (exception of april fools versions which we will skip)
+        // Versions url always gives list of versions from oldest to newest (exception of april fools versions which we filted already)
         // So iterating backwards will let us have newest be first option in dropdown.
-        for (let index = versions.length - 1; index >= 0; index--) {   
-            const neoforgeVersion = versions[index];
-            if (!neoforgeVersion.startsWith("0")) { // Skip 0.25w14craftmine and other april fools versions
-                var neoforgeVersionOption = document.createElement('option');
-                neoforgeVersionOption.value = neoforgeVersion;
-                neoforgeVersionOption.innerHTML = neoforgeVersion;
-                if (index == 0) {
-                    neoforgeVersionOption.selected = true;
-                }
-                allNeoforgeVersionSelect.appendChild(neoforgeVersionOption);
-            }
+        for (let index = neoforgeVersions.length - 1; index >= 0; index--) {   
+            const neoforgeVersion = neoforgeVersions[index];
+            var neoforgeVersionOption = document.createElement('option');
+            neoforgeVersionOption.value = neoforgeVersion;
+            neoforgeVersionOption.innerHTML = neoforgeVersion;
+            allNeoforgeVersionSelect.appendChild(neoforgeVersionOption);
         }
         document.querySelector(".fileinfo__body").appendChild(allNeoforgeVersionSelect);
         
-        // Creates the select element for NeoForge versions
+        // Creates the select element for visible eligible NeoForge versions
         var neoforgeVersionSelect = document.createElement('select');
         neoforgeVersionSelect.name = 'NeoForge Versions';
         neoforgeVersionSelect.id = 'neoforgeversions';
         neoforgeVersionSelect.onchange = function(){neoforgeValueChanged(this.value);};
+        // Use the current Minecraft version to know which NeoForge versions are eligible for selection.
         var neoforgeVersionPrefixForCurrentMinecraft = latestNeoForgeVersion.slice(0, 4);
-        // Versions url always gives list of versions from oldest to newest (exception of april fools versions which we will skip)
+        // Versions url always gives list of versions from oldest to newest (exception of april fools versions which we already filtered)
         // So iterating backwards will let us have newest be first option in dropdown.
-        for (let index = versions.length - 1; index >= 0; index--) {   
-            const neoforgeVersion = versions[index];
+        firstOption = true;
+        for (let index = neoforgeVersions.length - 1; index >= 0; index--) {   
+            const neoforgeVersion = neoforgeVersions[index];
              // Only get the neoforge versions for current minecraft version
-            if (!neoforgeVersion.startsWith("0") && neoforgeVersion.startsWith(neoforgeVersionPrefixForCurrentMinecraft)) {
+            if (neoforgeVersion.startsWith(neoforgeVersionPrefixForCurrentMinecraft)) {
                 var neoforgeVersionOption = document.createElement('option');
                 neoforgeVersionOption.value = neoforgeVersion;
                 neoforgeVersionOption.innerHTML = neoforgeVersion;
-                if (index == 0) {
+                if (firstOption) {
                     neoforgeVersionOption.selected = true;
+                    firstOption = false;
                 }
                 neoforgeVersionSelect.appendChild(neoforgeVersionOption);
             }

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -17,7 +17,10 @@ function setLinks(neoforgeVersion) {
         changelogUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(neoforgeVersion)}/neoforge-${encodeURIComponent(neoforgeVersion)}-changelog.txt`;
     }
 
-    document.getElementById("installerlink").href = installerUrl;
+    const installerLink = document.getElementById("installerlink");
+    installerLink.href = installerUrl;
+    installerLink.innerHTML = `<span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-${latestMinecraftVersion}-${latestNeoForgeVersion}-installer.jar</span></span>`;
+    
     document.getElementById("changeloglink").href = changelogUrl;
 }
 
@@ -33,12 +36,14 @@ function minecraftValueChanged(selectedMinecraftVersion) {
         if (!neoforgeVersion.startsWith(neoforgeVersionPrefixForCurrentMinecraft)) {
             option.hidden = true;
             option.disabled = true;
+            option.style.display = 'hidden';
             option.selected = false;
         }
         // Unhide versions that are for currently selected mc version
         else {
             option.hidden = false;
             option.disabled = false;
+            option.style.display = 'block';
 
             if (newestNeoforgeForCurrentMinecraft == undefined) {
                 newestNeoforgeForCurrentMinecraft = neoforgeVersion;
@@ -144,6 +149,7 @@ async function loadVersions() {
                 if (!neoforgeVersion.startsWith(neoforgeVersionPrefixForCurrentMinecraft)) {
                     neoforgeVersionOption.hidden = true;
                     neoforgeVersionOption.disabled = true;
+                    neoforgeVersionOption.style.display = 'hidden';
                 }
                 neoforgeVersionSelect.appendChild(neoforgeVersionOption);
             }

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -10,6 +10,7 @@ const DOWNLOAD_URL = "https://maven.neoforged.net/releases"
 function setLinks(neoforgeVersion) {
     const neoforgeDropdown = document.getElementById("neoforgeversions");
     const latestNeoforgeVersion = neoforgeDropdown.options[0].value;
+    const selectedMinecraftVersion = "1." + neoforgeVersion.slice(0, 4);
 
     const installerUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(neoforgeVersion)}/neoforge-${encodeURIComponent(neoforgeVersion)}-installer.jar`;
     let changelogUrl = "/changelog";
@@ -19,7 +20,7 @@ function setLinks(neoforgeVersion) {
 
     const installerLink = document.getElementById("installerlink");
     installerLink.href = installerUrl;
-    installerLink.innerHTML = `<span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-${latestMinecraftVersion}-${latestNeoForgeVersion}-installer.jar</span></span>`;
+    installerLink.innerHTML = `<span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-${selectedMinecraftVersion}-${neoforgeVersion}-installer.jar</span></span>`;
     
     document.getElementById("changeloglink").href = changelogUrl;
 }

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -7,78 +7,20 @@ const DOWNLOAD_URL = "https://maven.neoforged.net/releases"
 // For legacy version(s): https://maven.neoforged.net/api/maven/latest/version/releases/net/neoforged/forge?filter=1.20.1
 // To filter a specific MC version: https://maven.neoforged.net/api/maven/latest/version/releases/net/neoforged/neoforge?filter=20.4
 
-// Used for clearing the NeoForge version dropdown when a new Minecraft version is selected.
-// That way it can be populated with the new eligible NeoForge versions afterwards.
-function removeAllOptions(selectElement) {
-   let i;
-   let length = selectElement.options.length - 1
-   for(i = length; i >= 0; i--) {
-      selectElement.remove(i);
-   }
-}
+// Cache all neoforge versions in javascript variable.
+// This does persist as long as page stays loaded.
+const allNeoforgeVersions = [];
 
-function setLinks(neoforgeVersion) {
-    const allNeoforgeVersionDropdown = document.getElementById("allneoforgeversions");
-    const latestNeoforgeVersion = allNeoforgeVersionDropdown.options[0].value;
-    const selectedMinecraftVersion = "1." + neoforgeVersion.slice(0, 4);
+// Use JQuery to replace select element with select2 element that we can actually style ourselves.
+// Documentation: https://select2.org/getting-started/basic-usage
+$(document).ready(function() {
+    $('.select2-mode').select2();
+});
 
-    const installerUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(neoforgeVersion)}/neoforge-${encodeURIComponent(neoforgeVersion)}-installer.jar`;
-    const installerLink = document.getElementById("installerlink");
-    installerLink.href = installerUrl;
-    installerLink.innerHTML = `<span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-${selectedMinecraftVersion}-${neoforgeVersion}-installer.jar</span></span>`;
-    
-    // The latest changelog exists on the website at /changelog so we use that when latest NeoForge is selected.
-    // Otherwise use the maven changelog text file link.
-    let changelogUrl = "/changelog";
-    if (neoforgeVersion != latestNeoforgeVersion) {
-        changelogUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(neoforgeVersion)}/neoforge-${encodeURIComponent(neoforgeVersion)}-changelog.txt`;
-    }
-    document.getElementById("changeloglink").href = changelogUrl;
-}
-
-function minecraftValueChanged(selectedMinecraftVersion) {
-    var neoforgeVersionPrefixForCurrentMinecraft = selectedMinecraftVersion.slice(2, 6);
-
-    const allNeoforgeVersionDropdown = document.getElementById("allneoforgeversions");
-    const neoforgeDropdown = document.getElementById("neoforgeversions");
-
-    // Nuke all options as we will re-add the new eligible versions
-    removeAllOptions(neoforgeDropdown);
-    
-    let newestNeoforgeForCurrentMinecraft = undefined;
-    for (var index = 0; index < allNeoforgeVersionDropdown.options.length; index++) {
-        const option = allNeoforgeVersionDropdown.options[index];
-        const neoforgeVersion = option.value;
-
-        // Skip versions that are not eligible for current minecraft version
-        if (!neoforgeVersion.startsWith(neoforgeVersionPrefixForCurrentMinecraft)) {
-            continue;
-        }
-
-        var neoforgeVersionOption = document.createElement('option');
-        neoforgeVersionOption.value = neoforgeVersion;
-        neoforgeVersionOption.innerHTML = neoforgeVersion;
-
-        // Since allNeoforgeVersionDropdown is sorted by newest to oldest,
-        // we want to have the newest eligible NeoForge version selected by default when switching Minecraft versions. 
-        if (newestNeoforgeForCurrentMinecraft == undefined) {
-            newestNeoforgeForCurrentMinecraft = neoforgeVersion;
-            neoforgeVersionOption.selected = true;
-        }
-
-        neoforgeDropdown.appendChild(neoforgeVersionOption);
-    }
-
-    setLinks(newestNeoforgeForCurrentMinecraft);
-}
-
-function neoforgeValueChanged(selectedNeoforgeVersions) {
-    setLinks(selectedNeoforgeVersions);
-}
-
+// Runs once at page load to create the dropdowns with latest Minecraft and latest NeoForge version selected by default.
 async function loadVersions() {
     // Reminder, this endpoint will return all NeoForge versions with April Fools versions first, then oldest to newest versions afterwards.
-    let allVersionUrl = new URL(VERSIONS_ENDPOINT + encodeURIComponent(NEOFORGE_GAV));
+    const allVersionUrl = new URL(VERSIONS_ENDPOINT + encodeURIComponent(NEOFORGE_GAV));
     let neoforgeVersionsJson;
     try {
         const response = await fetch(allVersionUrl);
@@ -102,9 +44,8 @@ async function loadVersions() {
         const minecraftVersions = new Set([]);
         for (const neoforgeVersion of neoforgeVersions) {
             // The left 2 numbers for NeoForge versions is the last 2 numbers for Minecraft versions.
-            minecraftVersions.add("1." + neoforgeVersion.slice(0, 4)); 
+            minecraftVersions.add("1." + getFirstTwoVersionNumbers(neoforgeVersion)); 
         }
-
         // Sorts the mc versions so newest is topmost. We can't sort a set so convert to array first.
         const sortedMinecraftVersion = Array.from(minecraftVersions).sort(function (a,b) {
             return b.localeCompare(a, undefined, { numeric: true, sensitivity: 'base' });
@@ -112,10 +53,13 @@ async function loadVersions() {
         
         // Get newest NeoForge at end of the version list. Already future proofed to ignore April Fools version due to earlier filter.
         const latestNeoForgeVersion = neoforgeVersions[neoforgeVersions.length - 1];
+        // Use the latest NeoForge version to know which other NeoForge versions are also in the same current Minecraft version.
+        const neoforgeVersionPrefixForCurrentMinecraft = getFirstTwoVersionNumbers(latestNeoForgeVersion);
         // Get newest NeoForge version at start of the sorted minecraft version list.
         const latestMinecraftVersion = sortedMinecraftVersion[0];
+
         const latestInstallerUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(latestNeoForgeVersion)}/neoforge-${encodeURIComponent(latestNeoForgeVersion)}-installer.jar`;
-        const latestChangelogUrl = "/changelog"; // Always is the latest version's changelog on site.
+        const latestChangelogUrl = "/changelog"; // This URL is the latest version's changelog on site. Always kept up to date automatically.
         document.getElementById("filelist").innerHTML = `
             <div class="fileinfo__body">
                 <div class="selection_row">
@@ -133,69 +77,124 @@ async function loadVersions() {
             </div>
         `;
 
+        // Versions url always gives list of versions from oldest to newest (exception of april fools versions which we filted already)
+        // So iterating backwards will let us have newest be first option.
+        for (let index = neoforgeVersions.length - 1; index >= 0; index--) {   
+            allNeoforgeVersions.push(neoforgeVersions[index]);
+        }
         
         // Creates the select element for Minecraft versions
-        var minecraftVersionSelect = document.createElement('select');
-        minecraftVersionSelect.name = 'Minecraft Versions';
-        minecraftVersionSelect.id = 'minecraftversions';
-        minecraftVersionSelect.onchange = function(){minecraftValueChanged(this.value);};
-        // Populate the select with the Minecraft versions. First option selected by default.
-        let firstOption = true;
-        sortedMinecraftVersion.forEach(function(minecraftVersion) {
-            var minecraftVersionOption = document.createElement('option');
-            minecraftVersionOption.value = minecraftVersion;
-            minecraftVersionOption.innerHTML = minecraftVersion;
-            if (firstOption) {
-                minecraftVersionOption.selected = true;
-                firstOption = false;
-            }
-            minecraftVersionSelect.appendChild(minecraftVersionOption);
-        });
-        document.getElementById("minecraftversionscontainer").appendChild(minecraftVersionSelect);
-
-        // Creates the hidden select element for holding all neoforge versions.
-        // We need to do this because Safari will show hidden/disabled option elements.
-        // Thus this workaround by abusing a hidden select with all versions that we can use to populate the visible select with on Minecraft version change.
-        var allNeoforgeVersionSelect = document.createElement('select');
-        allNeoforgeVersionSelect.id = 'allneoforgeversions';
-        allNeoforgeVersionSelect.hidden = true;
-        allNeoforgeVersionSelect.disabled = true;
-        allNeoforgeVersionSelect.style.display = 'none';
-        // Versions url always gives list of versions from oldest to newest (exception of april fools versions which we filted already)
-        // So iterating backwards will let us have newest be first option in dropdown.
-        for (let index = neoforgeVersions.length - 1; index >= 0; index--) {   
-            const neoforgeVersion = neoforgeVersions[index];
-            var neoforgeVersionOption = document.createElement('option');
-            neoforgeVersionOption.value = neoforgeVersion;
-            neoforgeVersionOption.innerHTML = neoforgeVersion;
-            allNeoforgeVersionSelect.appendChild(neoforgeVersionOption);
-        }
-        document.querySelector(".fileinfo__body").appendChild(allNeoforgeVersionSelect);
-        
-        // Creates the select element for visible eligible NeoForge versions
-        var neoforgeVersionSelect = document.createElement('select');
-        neoforgeVersionSelect.name = 'NeoForge Versions';
-        neoforgeVersionSelect.id = 'neoforgeversions';
-        neoforgeVersionSelect.onchange = function(){neoforgeValueChanged(this.value);};
-        // Use the current Minecraft version to know which NeoForge versions are eligible for selection.
-        var neoforgeVersionPrefixForCurrentMinecraft = latestNeoForgeVersion.slice(0, 4);
-        // Versions url always gives list of versions from oldest to newest (exception of april fools versions which we already filtered)
-        // So iterating backwards will let us have newest be first option in dropdown.
-        firstOption = true;
-        for (let index = neoforgeVersions.length - 1; index >= 0; index--) {   
-            const neoforgeVersion = neoforgeVersions[index];
-             // Only get the neoforge versions for current minecraft version
-            if (neoforgeVersion.startsWith(neoforgeVersionPrefixForCurrentMinecraft)) {
-                var neoforgeVersionOption = document.createElement('option');
-                neoforgeVersionOption.value = neoforgeVersion;
-                neoforgeVersionOption.innerHTML = neoforgeVersion;
-                if (firstOption) {
-                    neoforgeVersionOption.selected = true;
-                    firstOption = false;
-                }
-                neoforgeVersionSelect.appendChild(neoforgeVersionOption);
-            }
-        }
-        document.getElementById("neoforgeversionscontainer").appendChild(neoforgeVersionSelect);
+        createAndPopulateSelectElement('Minecraft Versions', 'minecraftversions', minecraftValueChanged, sortedMinecraftVersion, "minecraftversionscontainer");
+       
+        // Creates the select element with NeoForge versions that are for the latest Minecraft version initially
+        const filteredNeoforgeVersion = allNeoforgeVersions.filter((neoforgeVersion) => neoforgeVersion.startsWith(neoforgeVersionPrefixForCurrentMinecraft));
+        createAndPopulateSelectElement('NeoForge Versions', 'neoforgeversions', neoforgeValueChanged, filteredNeoforgeVersion, "neoforgeversionscontainer");
     }
+}
+
+// Handles ensuring that the installer download and changelog links matches what the dropdown selections are.
+// Call this on dropdown value change.
+function setLinks(neoforgeVersion) {
+    const latestNeoforgeVersion = allNeoforgeVersions[0].value;
+    const selectedMinecraftVersion = "1." + getFirstTwoVersionNumbers(neoforgeVersion);
+
+    const installerUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(neoforgeVersion)}/neoforge-${encodeURIComponent(neoforgeVersion)}-installer.jar`;
+    const installerLink = document.getElementById("installerlink");
+    installerLink.href = installerUrl;
+    installerLink.innerHTML = `<span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-${selectedMinecraftVersion}-${neoforgeVersion}-installer.jar</span></span>`;
+    
+    // The latest changelog exists on the website at /changelog so we use that when latest NeoForge is selected.
+    // Otherwise use the maven changelog text file link.
+    let changelogUrl = "/changelog";
+    if (neoforgeVersion != latestNeoforgeVersion) {
+        changelogUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(neoforgeVersion)}/neoforge-${encodeURIComponent(neoforgeVersion)}-changelog.txt`;
+    }
+    document.getElementById("changeloglink").href = changelogUrl;
+}
+
+function minecraftValueChanged(selectedMinecraftVersion) {
+    const neoforgeVersionPrefixForCurrentMinecraft = getLastTwoVersionNumbers(selectedMinecraftVersion);
+
+    const neoforgeDropdown = document.getElementById("neoforgeversions");
+
+    // Nuke all NeoForge version options as we will re-add the new eligible versions
+    removeAllOptions(neoforgeDropdown);
+    
+    let newestNeoforgeForCurrentMinecraft = undefined;
+    for (let index = 0; index < allNeoforgeVersions.length; index++) {
+        const neoforgeVersion = allNeoforgeVersions[index];
+
+        // Skip versions that are not eligible for current minecraft version
+        if (!neoforgeVersion.startsWith(neoforgeVersionPrefixForCurrentMinecraft)) {
+            continue;
+        }
+
+        const neoforgeVersionOption = document.createElement('option');
+        neoforgeVersionOption.value = neoforgeVersion;
+        neoforgeVersionOption.innerHTML = neoforgeVersion;
+
+        // Since allNeoforgeVersions is sorted by newest to oldest,
+        // we want to find the NeoForge version that is the newest one for this new Minecraft version and have it selected. 
+        if (newestNeoforgeForCurrentMinecraft == undefined) {
+            newestNeoforgeForCurrentMinecraft = neoforgeVersion;
+            neoforgeVersionOption.selected = true;
+        }
+
+        neoforgeDropdown.appendChild(neoforgeVersionOption);
+    }
+
+    setLinks(newestNeoforgeForCurrentMinecraft);
+}
+
+function neoforgeValueChanged(selectedNeoforgeVersions) {
+    setLinks(selectedNeoforgeVersions);
+}
+
+// Split on first period and use everything afterwards.
+// So 1.21.1 becomes 21.1 which is the prefix for NeoForge versions on that Minecraft version.
+function getLastTwoVersionNumbers(versionString) {
+    return versionString.substring(versionString.indexOf('.') + 1);
+}
+
+// Split on periods and use only the first two version numbers
+// So 21.1.29 becomes 21.1 which is the prefix for NeoForge versions on that Minecraft version.
+function getFirstTwoVersionNumbers(versionString) {
+    let splitVersion = versionString.split('.');
+    return `${splitVersion[0]}.${splitVersion[1]}`;
+}
+
+// Used for clearing the NeoForge version dropdown when a new Minecraft version is selected.
+// That way it can be populated with the new eligible NeoForge versions afterwards.
+function removeAllOptions(selectElement) {
+   const length = selectElement.options.length - 1
+   for(let i = length; i >= 0; i--) {
+      selectElement.remove(i);
+   }
+}
+
+// Helper to setup the selects 
+function createAndPopulateSelectElement(name, id, valueChangeCallback, listOfOptionValues, idOfParentToAttachTo) {
+    const select = document.createElement('select');
+    select.name = name;
+    select.id = id;
+    select.classList.add("select2-mode");
+    select.onchange = function(){valueChangeCallback(this.value);};
+    
+    // Populate the select with the provided options.
+    // First option selected by default.
+    firstOption = true;
+    listOfOptionValues.forEach((optionValue) => {
+        const option = document.createElement('option');
+        option.value = optionValue;
+        option.innerHTML = optionValue;
+        if (firstOption) {
+            option.selected = true;
+            firstOption = false;
+        }
+        select.appendChild(option);
+    });
+    document.getElementById(idOfParentToAttachTo).appendChild(select);
+    
+    // Convert the above dropdown to select2 format.
+    $(`#${id}`).select2();
 }

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -55,6 +55,18 @@ async function loadLatestVersions(minecraftVersions) {
                 </div>
                 </details>
             `;
+
+            document.querySelector("projectlink").innerHTML = `
+                <div id="projectlink" class="fileinfo">
+                    <details${dropDown_VAL}>
+                        <summary class="fileinfo__header">For Other Versions</summary>
+                        <div class="fileinfo__body">
+                            <a href="https://projects.neoforged.net/neoforged/neoforge"><span class="fileinfo__icon"><i class="bi-file-earmark-arrow-down-fill" style="font-size: 2rem;"></i></span>
+                            <span class="fileinfo__content"><span>Click here to go to the version list!</span></span></a>
+                        </div>
+                    </details>
+                </div>
+            `;
         }
     }
 }

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -1,5 +1,5 @@
 const VERSIONS_ENDPOINT = "https://maven.neoforged.net/api/maven/versions/releases/"
-const FORGE_GAV = "net/neoforged/neoforge"
+const NEOFORGE_GAV = "net/neoforged/neoforge"
 const LEGACY_GAV = "net/neoforged/forge"
 const LATEST_ENDPOINT = "https://maven.neoforged.net/api/maven/latest/version/releases/"
 const DOWNLOAD_URL = "https://maven.neoforged.net/releases"
@@ -7,54 +7,105 @@ const DOWNLOAD_URL = "https://maven.neoforged.net/releases"
 // For legacy version(s): https://maven.neoforged.net/api/maven/latest/version/releases/net/neoforged/forge?filter=1.20.1
 // To filter a specific MC version: https://maven.neoforged.net/api/maven/latest/version/releases/net/neoforged/neoforge?filter=20.4
 
-async function loadVersions(minecraftVersions) {
-    for (const mcVersion of minecraftVersions) {
-        let gav = FORGE_GAV;
-        let fn = "neoforge";
-        let mcvers;
-        let dropDown_VAL = ` open="open"`;
-        let badges_beta = "";
-        let badges_new = "";
-        let badges_legacy = "";
-        let changelogUrl = "/changelog";
+async function loadVersions() {
+    let fn = "neoforge";
+    let mcvers;
+    let dropDown_VAL = ` open="open"`;
+    let badges_beta = "";
+    let badges_new = "";
+    let badges_legacy = "";
+    let changelogUrl = "/changelog";
 
-        let currentMcVersionUrl = new URL(LATEST_ENDPOINT + encodeURIComponent(gav));
-        let versionJson;
+    let allVersionUrl = new URL(VERSIONS_ENDPOINT + encodeURIComponent(NEOFORGE_GAV));
+    let versionsJson;
 
-        try {
-            const response = await fetch(currentMcVersionUrl);
-            versionJson = await response.json();
-        } catch (error) {
-            if (error instanceof SyntaxError) {
-                console.log("There was a SyntaxError parsing the JSON response from the maven server.", error);
-            } else {
-                console.log("There was an error processing the request for a new version.", error);
-            }
-        }
-
-        if (versionJson) {
-            const {version} = versionJson;
-            if (mcVersion == "latest") {
-                mcvers = "1." + version.slice(0, 4);
-            }
-            if (version.includes("beta")) {
-                badges_beta = `<font class="badges badges_beta">BETA</font>`;
-            }
-
-            const vs = `#filelist${mcVersion}`.split(".").join("");
-            const installerUrl = `${DOWNLOAD_URL}/${gav}/${encodeURIComponent(version)}/${fn}-${encodeURIComponent(version)}-installer.jar`;
-
-            document.querySelector(vs).innerHTML = `
-                <details${dropDown_VAL}>
-                <summary class="fileinfo__header">${badges_beta} ${badges_new} ${badges_legacy} NeoForge <code>${version}</code> for Minecraft ${mcvers}</summary>
-                <div class="fileinfo__body">
-                <a href="${installerUrl}"><span class="fileinfo__icon"><i class="bi-file-earmark-zip-fill" style="font-size: 2rem;"></i></span>
-			    <span class="fileinfo__content"><span>Latest <em>NeoForge</em> Installer</span><span class="installer-version">${fn}-${version}-installer.jar</span></span></a>
-                <a href="${changelogUrl}"><span class="fileinfo__icon"><i class="bi-file-earmark-text-fill" style="font-size: 2rem;"></i></span>
-			    <span class="fileinfo__content"><span>Latest Changelog</span><span>${version}</span></span></a>
-                </div>
-                </details>
-            `;
+    try {
+        const response = await fetch(allVersionUrl);
+        versionsJson = await response.json();
+    } catch (error) {
+        if (error instanceof SyntaxError) {
+            console.log("There was a SyntaxError parsing the JSON response from the maven server.", error);
+        } else {
+            console.log("There was an error processing the request for a new version.", error);
         }
     }
+
+    if (versionsJson) {
+        const {versions} = versionJson;
+        if (mcVersion == "latest") {
+            mcvers = "1." + version.slice(0, 4);
+        }
+
+        const vs = `filelist${mcVersion}`.split(".").join("");
+
+        document.getElementById(vs).innerHTML = `
+            <details${dropDown_VAL}>
+            <summary class="fileinfo__header">${badges_beta} ${badges_new} ${badges_legacy} NeoForge <code>${version}</code> for Minecraft ${mcvers}</summary>
+            <div class="fileinfo__body">
+            <a href="${installerUrl}"><span class="fileinfo__icon"><i class="bi-file-earmark-zip-fill" style="font-size: 2rem;"></i></span>
+            <span class="fileinfo__content"><span>Latest <em>NeoForge</em> Installer</span><span class="installer-version">${fn}-${version}-installer.jar</span></span></a>
+            <a href="${changelogUrl}"><span class="fileinfo__icon"><i class="bi-file-earmark-text-fill" style="font-size: 2rem;"></i></span>
+            <span class="fileinfo__content"><span>Latest Changelog</span><span>${version}</span></span></a>
+            </div>
+            </details>
+        `;
+
+        document.querySelector(vs).innerHTML = `
+            <div class="fileinfo__body">
+                <div class="selection_row">
+                    <div class="selection_block">
+                        <label for="minecraftversions">Minecraft Version:&nbsp;</label>
+                        <select name="Minecraft Versions" id="minecraftversions" onchange="minecraftValueChanged(this.value)">
+                            <option value="">Loading...</option>
+                        </select>
+                    </div>
+                    <div class="selection_block">
+                        <label for="neoforgeversions">NeoForge Version:&nbsp;</label>
+                        <select name="Neoforge Versions" id="neoforgeversions" onchange="neoforgeValueChanged(this.value)">
+                            <option value="">Loading...</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="download_row">
+                    <a id="installerlink" href="${installerUrl}><span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-0.00.00-00.00.00-installer.jar</span></span></a>
+                    <a id="changeloglink" href="${changelogUrl}><span>See changelog</span></a>
+                </div>
+            </div>
+        `;
+    }
+}
+
+async function minecraftValueChanged(selectedMinecraftVersion) {
+
+    const selectedMinecraftVersion = document.getElementById("minecraftversions").value;
+    let allVersionUrl = new URL(VERSIONS_ENDPOINT + encodeURIComponent(NEOFORGE_GAV));
+
+    let versionJson;
+    try {
+        const response = await fetch(allVersionUrl);
+        versionJson = await response.json();
+    } catch (error) {
+        if (error instanceof SyntaxError) {
+            console.log("There was a SyntaxError parsing the JSON response from the maven server.", error);
+        } else {
+            console.log("There was an error processing the request for a new version.", error);
+        }
+    }
+
+    const neoforgeDropdown = document.getElementById("neoforgeversions");
+    //const selectedNeoforgeVersions = .value;
+
+    setLinks(selectedNeoforgeVersions);
+}
+
+async function neoforgeValueChanged(selectedNeoforgeVersions) {
+    setLinks(selectedNeoforgeVersions);
+}
+
+async function setLinks(neoforgeVersion) {
+    const installerUrl = `${DOWNLOAD_URL}/${gav}/${encodeURIComponent(neoforgeVersion)}/${fn}-${encodeURIComponent(neoforgeVersion)}-installer.jar`;
+    const changelogUrl = `${DOWNLOAD_URL}/${gav}/${encodeURIComponent(neoforgeVersion)}/${fn}-${encodeURIComponent(neoforgeVersion)}-changelog.txt`;
+
+    document.getElementById("installerlink").href = installerUrl;
+    document.getElementById("changeloglink").href = changelogUrl;
 }

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -7,7 +7,7 @@ const DOWNLOAD_URL = "https://maven.neoforged.net/releases"
 // For legacy version(s): https://maven.neoforged.net/api/maven/latest/version/releases/net/neoforged/forge?filter=1.20.1
 // To filter a specific MC version: https://maven.neoforged.net/api/maven/latest/version/releases/net/neoforged/neoforge?filter=20.4
 
-async function loadLatestVersions(minecraftVersions) {
+async function loadVersions(minecraftVersions) {
     for (const mcVersion of minecraftVersions) {
         let gav = FORGE_GAV;
         let fn = "neoforge";
@@ -55,8 +55,6 @@ async function loadLatestVersions(minecraftVersions) {
                 </div>
                 </details>
             `;
-
-            document.querySelector("#projectlinkdetails").open = true;
         }
     }
 }

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -16,8 +16,8 @@ function removeAllOptions(selectElement) {
 }
 
 function setLinks(neoforgeVersion) {
-    const neoforgeDropdown = document.getElementById("neoforgeversions");
-    const latestNeoforgeVersion = neoforgeDropdown.options[0].value;
+    const allNeoforgeVersionDropdown = document.getElementById("allneoforgeversions");
+    const latestNeoforgeVersion = allNeoforgeVersionDropdown.options[0].value;
     const selectedMinecraftVersion = "1." + neoforgeVersion.slice(0, 4);
 
     const installerUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(neoforgeVersion)}/neoforge-${encodeURIComponent(neoforgeVersion)}-installer.jar`;

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -11,10 +11,10 @@ function setLinks(neoforgeVersion) {
     const selectedMinecraftVersion = "1." + neoforgeVersion.slice(0, 4);
 
     const mainMinecraftDropdown = document.getElementById("minecraft-versions");
-    mainMinecraftDropdown.innerHTML = `${selectedMinecraftVersion}<span style="float: inline-end;">▼</span>`;
+    mainMinecraftDropdown.innerHTML = `${selectedMinecraftVersion}<span style="float: inline-end;">⮟</span>`;
 
     const mainNeoforgeDropdown = document.getElementById("neoforge-versions");
-    mainNeoforgeDropdown.innerHTML = `${neoforgeVersion}<span style="float: inline-end;">▼</span>`;
+    mainNeoforgeDropdown.innerHTML = `${neoforgeVersion}<span style="float: inline-end;">⮟</span>`;
 
     const allNeoforgeVersionDropdown = document.getElementById("all-neoforge-versions");
     const latestNeoforgeVersion = allNeoforgeVersionDropdown.options[0].value;
@@ -221,7 +221,7 @@ function createDropdownButton(name, id, optionClass, dataname, listOfButtonOptio
     populateDropdown(dropdownContentDiv, optionClass, dataname, listOfButtonOptions, optionOnclickFunction);
 
     // Default to newest version displayed
-    dropdownMainButton.innerHTML = `${listOfButtonOptions[0]}<span style="float: inline-end;">▼</span>`;
+    dropdownMainButton.innerHTML = `${listOfButtonOptions[0]}<span style="float: inline-end;">⮟</span>`;
     
     dropdownContainer.appendChild(dropdownMainButton);
     dropdownContainer.appendChild(dropdownContentDiv);

--- a/assets/js/neoforge.js
+++ b/assets/js/neoforge.js
@@ -8,8 +8,14 @@ const DOWNLOAD_URL = "https://maven.neoforged.net/releases"
 // To filter a specific MC version: https://maven.neoforged.net/api/maven/latest/version/releases/net/neoforged/neoforge?filter=20.4
 
 function setLinks(neoforgeVersion) {
+    const neoforgeDropdown = document.getElementById("neoforgeversions");
+    const latestNeoforgeVersion = neoforgeDropdown.options[0].value;
+
     const installerUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(neoforgeVersion)}/neoforge-${encodeURIComponent(neoforgeVersion)}-installer.jar`;
-    const changelogUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(neoforgeVersion)}/neoforge-${encodeURIComponent(neoforgeVersion)}-changelog.txt`;
+    let changelogUrl = "/changelog";
+    if (neoforgeVersion != latestNeoforgeVersion) {
+        changelogUrl = `${DOWNLOAD_URL}/${NEOFORGE_GAV}/${encodeURIComponent(neoforgeVersion)}/neoforge-${encodeURIComponent(neoforgeVersion)}-changelog.txt`;
+    }
 
     document.getElementById("installerlink").href = installerUrl;
     document.getElementById("changeloglink").href = changelogUrl;
@@ -24,9 +30,10 @@ function minecraftValueChanged(selectedMinecraftVersion) {
         const option = neoforgeDropdown.options[index];
         const neoforgeVersion = option.value;
         // Hide versions that are not for the currently selected mc version
-        if (!neoforgeVersion.startswith(neoforgeVersionPrefixForCurrentMinecraft)) {
+        if (!neoforgeVersion.startsWith(neoforgeVersionPrefixForCurrentMinecraft)) {
             option.hidden = true;
             option.disabled = true;
+            option.selected = false;
         }
         // Unhide versions that are for currently selected mc version
         else {
@@ -35,6 +42,7 @@ function minecraftValueChanged(selectedMinecraftVersion) {
 
             if (newestNeoforgeForCurrentMinecraft == undefined) {
                 newestNeoforgeForCurrentMinecraft = neoforgeVersion;
+                option.selected = true;
             }
         }
     }
@@ -61,15 +69,15 @@ async function loadVersions() {
     }
 
     if (neoforgeVersionsJson) {
-        const {neoforgeVersions} = neoforgeVersionsJson;
+        const {versions} = neoforgeVersionsJson;
         const minecraftVersions = new Set([]);
-        for (const neoforgeVersion of neoforgeVersions) {
-            if (!neoforgeVersion.startswith("0")) { // Skip 0.25w14craftmine and other april fools versions
+        for (const neoforgeVersion of versions) {
+            if (!neoforgeVersion.startsWith("0")) { // Skip 0.25w14craftmine and other april fools versions
                 minecraftVersions.add("1." + neoforgeVersion.slice(0, 4)); // Grab the Minecraft version from the NeoForge versions
             }
         }
         // Sorts the mc versions so newest is topmost. Done because we used a set to prevent duplicate minecraft versions quickly.
-        const sortedMinecraftVersion = minecraftVersions.sort(function (a,b) {
+        const sortedMinecraftVersion = Array.from(minecraftVersions).sort(function (a,b) {
             return b.localeCompare(a, undefined, { numeric: true, sensitivity: 'base' });
         });
         
@@ -88,8 +96,8 @@ async function loadVersions() {
                     </div>
                 </div>
                 <div class="download_row">
-                    <a id="installerlink" href="${latestInstallerUrl}><span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-${latestMinecraftVersion}-${latestNeoForgeVersion}-installer.jar</span></span></a>
-                    <a id="changeloglink" href="${latestChangelogUrl}><span>See changelog</span></a>
+                    <a id="installerlink" href="${latestInstallerUrl}"><span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-${latestMinecraftVersion}-${latestNeoForgeVersion}-installer.jar</span></span></a>
+                    <a id="changeloglink" href="${latestChangelogUrl}"><span>See changelog</span></a>
                 </div>
             </div>
         `;
@@ -123,9 +131,9 @@ async function loadVersions() {
         var neoforgeVersionPrefixForCurrentMinecraft = latestNeoForgeVersion.slice(0, 4);
         // Versions url always gives list of versions from oldest to newest (exception of april fools versions which we will skip)
         // So iterating backwards will let us have newest be first option in dropdown.
-        for (let index = neoforgeVersions.length - 1; index >= 0; index--) {   
-            const neoforgeVersion = neoforgeVersions[index];
-            if (!neoforgeVersion.startswith("0")) { // Skip 0.25w14craftmine and other april fools versions
+        for (let index = versions.length - 1; index >= 0; index--) {   
+            const neoforgeVersion = versions[index];
+            if (!neoforgeVersion.startsWith("0")) { // Skip 0.25w14craftmine and other april fools versions
                 var neoforgeVersionOption = document.createElement('option');
                 neoforgeVersionOption.value = neoforgeVersion;
                 neoforgeVersionOption.innerHTML = neoforgeVersion;
@@ -133,7 +141,7 @@ async function loadVersions() {
                     neoforgeVersionOption.selected = true;
                 }
                 // Hide versions that are not for the currently selected mc version
-                if (!neoforgeVersion.startswith(neoforgeVersionPrefixForCurrentMinecraft)) {
+                if (!neoforgeVersion.startsWith(neoforgeVersionPrefixForCurrentMinecraft)) {
                     neoforgeVersionOption.hidden = true;
                     neoforgeVersionOption.disabled = true;
                 }

--- a/content/_index.md
+++ b/content/_index.md
@@ -9,8 +9,6 @@ summary: |
 description: |
     NeoForged installer files, as well as news and other information from the NeoForged project
 ---
-# NeoForge installer files
-You can find a direct link to our latest installer files below.
 
 {{< files >}}
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,7 +12,7 @@ description: |
 # NeoForge installer files
 You can find a direct link to our latest installer files below.
 
-{{< files "latest" >}}
+{{< files >}}
 
 # Using NeoForge for mod development
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -13,7 +13,6 @@ description: |
 You can find a direct link to our latest installer files below.
 
 {{< files "latest" >}}
-{{< versions >}}
 
 # Using NeoForge for mod development
 

--- a/layouts/shortcodes/files.html
+++ b/layouts/shortcodes/files.html
@@ -6,19 +6,32 @@
 
 
     <div id="filelist{{ replace (.Get 0) "." "" }}" class="fileinfo">
-        <details>
-            <summary class="fileinfo__header">NeoForge (loading version...)</summary>
-            <div class="fileinfo__body">
-                <a><span>Latest <em>NeoForge</em> Installer</span><span class="fileinfo__placeholder">neoforge-0.00.00-00.00.00-installer.jar</span></a>
-                <a><span>Latest Changelog</span><span class="fileinfo__placeholder">0.00.00-00.00.00</span></a>
+        <div class="fileinfo__body">
+            <div class="selection_row">
+                <div class="selection_block">
+                    <label for="minecraftversions">Minecraft Version:&nbsp;</label>
+                    <select name="Minecraft Versions" id="minecraftversions">
+                        <option value="">Loading...</option>
+                    </select>
+                </div>
+                <div class="selection_block">
+                    <label for="neoforgeversions">NeoForge Version:&nbsp;</label>
+                    <select name="Neoforge Versions" id="neoforgeversions">
+                        <option value="">Loading...</option>
+                    </select>
+                </div>
             </div>
-        </details>
+            <div class="download_row">
+                <a class="installerlink"><span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-0.00.00-00.00.00-installer.jar</span></span></a>
+                <a class="changeloglink"><span>See changelog</span></a>
+            </div>
+        </div>
     </div>
 
 <script>
     document.addEventListener("readystatechange", evt=>{
         if (evt.target.readyState === "complete") {
-            loadLatestVersions([{{ .Get 0 }}]);
+            //loadVersions([{{ .Get 0 }}]);
         }
     });
 </script>

--- a/layouts/shortcodes/files.html
+++ b/layouts/shortcodes/files.html
@@ -21,8 +21,8 @@
                 </div>
             </div>
             <div class="download_row">
-                <a id="installerlink"><span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-0.00.00-00.00.00-installer.jar</span></span></a>
-                <a id="changeloglink"><span>See changelog</span></a>
+                <a id="installerlink"><span>Loading...</span></a>
+                <a id="changeloglink"><span>Loading...</span></a>
             </div>
         </div>
     </div>

--- a/layouts/shortcodes/files.html
+++ b/layouts/shortcodes/files.html
@@ -31,7 +31,7 @@
                 </div>
                 <!--Inlined styles to ensure the one time loading phase looks correct and matched populated phase-->
                 <div class="download_row" style="flex-grow: 2;">
-                    <a id="installerlink" style="line-height: 320%;"><span>Loading...</span></a>
+                    <a id="installerlink"><span>Loading...</span></a>
                     <a id="changeloglink"><span>Loading...</span></a>
                 </div>
             </div>

--- a/layouts/shortcodes/files.html
+++ b/layouts/shortcodes/files.html
@@ -1,3 +1,6 @@
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 {{ if not ( .Page.Scratch.Get "nfJS") }}
   {{ $js:= resources.Get "js/neoforge.js" }}
   <script src="{{ $js.RelPermalink }}"></script>
@@ -9,13 +12,13 @@
             <div class="selection_row">
                 <div class="selection_block">
                     <label for="minecraftversions">Minecraft Version:&nbsp;</label>
-                    <select name="Minecraft Versions" id="minecraftversions">
+                    <select name="Minecraft Versions" id="minecraftversions" class="select2-mode">
                         <option value="">Loading...</option>
                     </select>
                 </div>
                 <div class="selection_block">
                     <label for="neoforgeversions">NeoForge Version:&nbsp;</label>
-                    <select name="Neoforge Versions" id="neoforgeversions">
+                    <select name="Neoforge Versions" id="neoforgeversions" class="select2-mode">
                         <option value="">Loading...</option>
                     </select>
                 </div>

--- a/layouts/shortcodes/files.html
+++ b/layouts/shortcodes/files.html
@@ -7,25 +7,33 @@
   {{ .Page.Scratch.Set "nfJS" "hi" }}
 {{ end }}
 
-    <div id="filelist" class="fileinfo">
-        <div class="fileinfo__body">
-            <div class="selection_row">
-                <div class="selection_block">
-                    <label for="minecraftversions">Minecraft Version:&nbsp;</label>
-                    <select name="Minecraft Versions" id="minecraftversions" class="select2-mode" disabled>
-                        <option value="">Loading...</option>
-                    </select>
+    <div id="installerSection" class="installer_section">
+        <div>
+            <h1>NeoForge installer files</h1>
+            <p>You can find a direct link to our installer files here:</p>
+        </div>
+
+        <div id="filelist" class="fileinfo">
+            <div class="fileinfo__body">
+                <div class="selection_row">
+                    <div class="selection_block">
+                        <label for="minecraftversions">Minecraft Version:&nbsp;</label>
+                        <select name="Minecraft Versions" id="minecraftversions" class="select2-mode" disabled>
+                            <option value="">Loading...</option>
+                        </select>
+                    </div>
+                    <div class="selection_block">
+                        <label for="neoforgeversions">NeoForge Version:&nbsp;</label>
+                        <select name="Neoforge Versions" id="neoforgeversions" class="select2-mode" disabled>
+                            <option value="">Loading...</option>
+                        </select>
+                    </div>
                 </div>
-                <div class="selection_block">
-                    <label for="neoforgeversions">NeoForge Version:&nbsp;</label>
-                    <select name="Neoforge Versions" id="neoforgeversions" class="select2-mode" disabled>
-                        <option value="">Loading...</option>
-                    </select>
+                <!--Inlined styles to ensure the one time loading phase looks correct and matched populated phase-->
+                <div class="download_row" style="flex-grow: 2;">
+                    <a id="installerlink" style="line-height: 320%;"><span>Loading...</span></a>
+                    <a id="changeloglink"><span>Loading...</span></a>
                 </div>
-            </div>
-            <div class="download_row">
-                <a id="installerlink"><span>Loading...</span></a>
-                <a id="changeloglink"><span>Loading...</span></a>
             </div>
         </div>
     </div>

--- a/layouts/shortcodes/files.html
+++ b/layouts/shortcodes/files.html
@@ -12,13 +12,13 @@
             <div class="selection_row">
                 <div class="selection_block">
                     <label for="minecraftversions">Minecraft Version:&nbsp;</label>
-                    <select name="Minecraft Versions" id="minecraftversions" class="select2-mode">
+                    <select name="Minecraft Versions" id="minecraftversions" class="select2-mode" disabled>
                         <option value="">Loading...</option>
                     </select>
                 </div>
                 <div class="selection_block">
                     <label for="neoforgeversions">NeoForge Version:&nbsp;</label>
-                    <select name="Neoforge Versions" id="neoforgeversions" class="select2-mode">
+                    <select name="Neoforge Versions" id="neoforgeversions" class="select2-mode" disabled>
                         <option value="">Loading...</option>
                     </select>
                 </div>

--- a/layouts/shortcodes/files.html
+++ b/layouts/shortcodes/files.html
@@ -8,16 +8,30 @@
         <div class="fileinfo__body">
             <div class="selection_row">
                 <div class="selection_block">
-                    <label for="minecraftversions">Minecraft Version:&nbsp;</label>
-                    <select name="Minecraft Versions" id="minecraftversions">
-                        <option value="">Loading...</option>
-                    </select>
+                    <label for="minecraft-versions">Minecraft Version:&nbsp;</label>
+                    <div class="dropdown">
+                        <button
+                            name="Minecraft Versions"
+                            id="minecraft-versions"
+                            class="dropbtn"
+                            data-dropdown-content-id="minecraft-version-dropdown-content"
+                        >
+                            Loading...
+                        </button>
+                    </div> 
                 </div>
                 <div class="selection_block">
-                    <label for="neoforgeversions">NeoForge Version:&nbsp;</label>
-                    <select name="Neoforge Versions" id="neoforgeversions">
-                        <option value="">Loading...</option>
-                    </select>
+                    <label for="neoforge-versions">NeoForge Version:&nbsp;</label>
+                    <div class="dropdown">
+                        <button
+                            name="Neoforge Versions"
+                            id="neoforge-versions"
+                            class="dropbtn"
+                            data-dropdown-content-id="neoforge-version-dropdown-content"
+                        >
+                            Loading...
+                        </button>
+                    </div> 
                 </div>
             </div>
             <div class="download_row">

--- a/layouts/shortcodes/files.html
+++ b/layouts/shortcodes/files.html
@@ -8,30 +8,16 @@
         <div class="fileinfo__body">
             <div class="selection_row">
                 <div class="selection_block">
-                    <label for="minecraft-versions">Minecraft Version:&nbsp;</label>
-                    <div class="dropdown">
-                        <button
-                            name="Minecraft Versions"
-                            id="minecraft-versions"
-                            class="dropbtn"
-                            data-dropdown-content-id="minecraft-version-dropdown-content"
-                        >
-                            Loading...
-                        </button>
-                    </div> 
+                    <label for="minecraftversions">Minecraft Version:&nbsp;</label>
+                    <select name="Minecraft Versions" id="minecraftversions">
+                        <option value="">Loading...</option>
+                    </select>
                 </div>
                 <div class="selection_block">
-                    <label for="neoforge-versions">NeoForge Version:&nbsp;</label>
-                    <div class="dropdown">
-                        <button
-                            name="Neoforge Versions"
-                            id="neoforge-versions"
-                            class="dropbtn"
-                            data-dropdown-content-id="neoforge-version-dropdown-content"
-                        >
-                            Loading...
-                        </button>
-                    </div> 
+                    <label for="neoforgeversions">NeoForge Version:&nbsp;</label>
+                    <select name="Neoforge Versions" id="neoforgeversions">
+                        <option value="">Loading...</option>
+                    </select>
                 </div>
             </div>
             <div class="download_row">

--- a/layouts/shortcodes/files.html
+++ b/layouts/shortcodes/files.html
@@ -1,11 +1,6 @@
-{{ if not ( .Page.Scratch.Get "nfJS") }}
-  {{ $js:= resources.Get "js/neoforge.js" }}
-  <script src="{{ $js.RelPermalink }}"></script>
-  {{ .Page.Scratch.Set "nfJS" "hi" }}
-{{ end }}
+<script src="{{ "js/neoforge.js" | relURL }}"></script>
 
-
-    <div id="filelist{{ replace (.Get 0) "." "" }}" class="fileinfo">
+    <div id="filelist" class="fileinfo">
         <div class="fileinfo__body">
             <div class="selection_row">
                 <div class="selection_block">
@@ -22,8 +17,8 @@
                 </div>
             </div>
             <div class="download_row">
-                <a class="installerlink"><span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-0.00.00-00.00.00-installer.jar</span></span></a>
-                <a class="changeloglink"><span>See changelog</span></a>
+                <a id="installerlink"><span>Click Here to Download:&nbsp;<br><span class="normal__font__weight">neoforge-0.00.00-00.00.00-installer.jar</span></span></a>
+                <a id="changeloglink"><span>See changelog</span></a>
             </div>
         </div>
     </div>
@@ -31,7 +26,7 @@
 <script>
     document.addEventListener("readystatechange", evt=>{
         if (evt.target.readyState === "complete") {
-            //loadVersions([{{ .Get 0 }}]);
+            loadVersions();
         }
     });
 </script>

--- a/layouts/shortcodes/files.html
+++ b/layouts/shortcodes/files.html
@@ -1,4 +1,8 @@
-<script src="{{ "js/neoforge.js" | relURL }}"></script>
+{{ if not ( .Page.Scratch.Get "nfJS") }}
+  {{ $js:= resources.Get "js/neoforge.js" }}
+  <script src="{{ $js.RelPermalink }}"></script>
+  {{ .Page.Scratch.Set "nfJS" "hi" }}
+{{ end }}
 
     <div id="filelist" class="fileinfo">
         <div class="fileinfo__body">

--- a/layouts/shortcodes/versions.html
+++ b/layouts/shortcodes/versions.html
@@ -1,5 +1,5 @@
 <div id="projectlink" class="fileinfo">
-    <details>
+    <details open="open">
         <summary class="fileinfo__header">For Other Versions</summary>
         <div class="fileinfo__body">
             <a href="https://projects.neoforged.net/neoforged/neoforge"><span class="fileinfo__icon"><i class="bi-file-earmark-arrow-down-fill" style="font-size: 2rem;"></i></span>

--- a/layouts/shortcodes/versions.html
+++ b/layouts/shortcodes/versions.html
@@ -1,9 +1,0 @@
-<div id="projectlink" class="fileinfo">
-    <details id="projectlinkdetails">
-        <summary class="fileinfo__header">For Other Versions</summary>
-        <div class="fileinfo__body">
-            <a href="https://projects.neoforged.net/neoforged/neoforge"><span class="fileinfo__icon"><i class="bi-file-earmark-arrow-down-fill" style="font-size: 2rem;"></i></span>
-            <span class="fileinfo__content"><span>Click here to go to the version list!</span></span></a>
-        </div>
-    </details>
-</div>

--- a/layouts/shortcodes/versions.html
+++ b/layouts/shortcodes/versions.html
@@ -1,5 +1,5 @@
 <div id="projectlink" class="fileinfo">
-    <details open="open">
+    <details>
         <summary class="fileinfo__header">For Other Versions</summary>
         <div class="fileinfo__body">
             <a href="https://projects.neoforged.net/neoforged/neoforge"><span class="fileinfo__icon"><i class="bi-file-earmark-arrow-down-fill" style="font-size: 2rem;"></i></span>

--- a/layouts/shortcodes/versions.html
+++ b/layouts/shortcodes/versions.html
@@ -1,5 +1,5 @@
 <div id="projectlink" class="fileinfo">
-    <details>
+    <details id="projectlinkdetails">
         <summary class="fileinfo__header">For Other Versions</summary>
         <div class="fileinfo__body">
             <a href="https://projects.neoforged.net/neoforged/neoforge"><span class="fileinfo__icon"><i class="bi-file-earmark-arrow-down-fill" style="font-size: 2rem;"></i></span>

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1080,6 +1080,11 @@ summary code:hover {
 }
 
 /* Installer */
+#filelist {
+	margin-left: auto;
+	margin-right: auto;
+}
+
 .fileinfo {
 	text-align: center;
 	margin: 0 0 20px;
@@ -1181,6 +1186,20 @@ summary code:hover {
 	border-radius: 4px;
 	font-family: monospace;
 }
+
+#changeloglink {
+	background-color: var(--color-outlined-download-body);
+	border: solid var(--color-outlined-download) 2px;
+}
+
+#changeloglink:hover {
+	background-color: var(--color-outlined-download-body-highlight);
+	border: solid var(--color-outlined-download-highlight) 2px;
+}
+
+.fileinfo .fileinfo__body a {
+}
+
 
 /* Changelogs */
 .changelog_body {
@@ -1459,6 +1478,10 @@ a.anchor-wrapper:hover, a.anchor-wrapper:focus {
 	--color-border-badges-legacy: #53d8da;
 	--color-download: #e68c37;
 	--color-download-highlight: #e5b04c;
+	--color-outlined-download: #e68c37;
+	--color-outlined-download-highlight: #e5b04c;
+	--color-outlined-download-body: #d0dcdb;
+	--color-outlined-download-body-highlight: #eaeaea;
 	--color-selection-box-background: #b1b8be;
 	--color-box: #bdc7c7;
 	--color-outer: #bdc7c7;
@@ -1492,6 +1515,10 @@ a.anchor-wrapper:hover, a.anchor-wrapper:focus {
 	--color-background: #222427;
 	--color-download: #a94e0d;
 	--color-download-highlight: #d88231;
+	--color-outlined-download: #a94e0d;
+	--color-outlined-download-highlight: #d88231;
+	--color-outlined-download-body: #2e3135;
+	--color-outlined-download-body-highlight: #484a4d;
 	--color-box: #2e3135;
 	--color-outer: #111111;
 	--color-border: #5a5a5a;

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1133,6 +1133,17 @@ summary code:hover {
 	max-width: 200px;
 	margin-left: auto;
 	text-align: left;
+	color: black;
+}
+
+.select2-search__field {
+	background-color: rgb(225, 225, 225);
+	color: black;
+}
+
+.select2-dropdown {
+	background-color: white;
+	color: black;
 }
 
 .fileinfo .fileinfo__body a {
@@ -1477,7 +1488,7 @@ a.anchor-wrapper:hover, a.anchor-wrapper:focus {
 	--color-border-badges-new: #8b5460;
 	--color-border-badges-legacy: #227778;
 	--color-background: #222427;
-	--color-download: #d7742f;
+	--color-download: #aa5518;
 	--color-download-highlight: #e68c37;
 	--color-box: #2e3135;
 	--color-outer: #111111;

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1128,6 +1128,12 @@ summary code:hover {
 	position: relative;
 }
 
+.fileinfo .fileinfo__body .selection_row .selection_block select{
+	max-width: 200px;
+	flex-grow: 1;
+	margin-left: auto;
+}
+
 .fileinfo .fileinfo__body a {
 	margin: 0px 10px 10px 10px;
 	padding: .625rem;
@@ -1155,72 +1161,6 @@ summary code:hover {
 .installer-version {
 	font-family: monospace;
 }
-
-/* Modified custom dropdown element from: https://www.w3schools.com/howto/howto_js_dropdown.asp */
-/* The container <div> - needed to position the dropdown content */
-.dropdown {
-	position: relative;
-	margin-left: auto;
-	display: inline;
-}
-
-/* Dropdown Button */
-.dropbtn {
-	background-color: #efefef;
-	color: rgb(0, 0, 0);
-	text-align: left;
-	width: 200px;
-	font-size: 16px;
-	border-radius: 4px;
-	border: 1px rgb(146, 146, 146);
-	border-style: solid;
-	cursor: pointer;
-}
-
-/* Dropdown button on hover & focus */
-.dropbtn:hover, .dropbtn:focus {
-	background-color: #c5c5c5;
-}
-
-/* Dropdown Content (Hidden by Default) */
-.dropdown-content {
-	display: none;
-	position: absolute;
-	background-color: #f1f1f1;
-	width: 200px;
-	box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-	z-index: 1;
-	border-radius: 4px;
-	max-height: 180px;
-	overflow: scroll;
-	overflow-x: hidden;
-}
-
-.selectedOption {
-	background-color: #e0c388;
-}
-
-/* Button inside the dropdown */
-.dropdown-content button {
-	color: black;
-	text-decoration: none;
-	display: block;
-	border-radius: 0;
-	border: none;
-	width: 100%;
-	text-align: left;
-	border-radius: 4px;
-}
-
-/* Change color of dropdown button on hover */
-.dropdown-content button:hover {
-	background-color: #d2d2d2;
-}
-
-/* Show the dropdown menu (use JS to add this class to the .dropdown-content container when the user clicks on the dropdown button) */
-.show {
-	display: block;
-} 
 
 /* Badges */
 .badges {
@@ -1465,12 +1405,11 @@ summary code:hover {
 		flex-direction: column;
 	}
 
-	.fileinfo .fileinfo__body .selection_row .selection_block .dropdown {
-		max-width: fit-content;
+	.fileinfo .fileinfo__body .selection_row .selection_block select{
+		max-width: none;
 		margin-top: 4px;
 		margin-bottom: 4px;
-		margin-left: auto;
-		margin-right: auto;
+		margin-left: 0px;
 	}
 }
 

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1488,7 +1488,7 @@ a.anchor-wrapper:hover, a.anchor-wrapper:focus {
 	--color-border-badges-new: #8b5460;
 	--color-border-badges-legacy: #227778;
 	--color-background: #222427;
-	--color-download: #aa5518;
+	--color-download: #9d4405;
 	--color-download-highlight: #e68c37;
 	--color-box: #2e3135;
 	--color-outer: #111111;

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1091,7 +1091,6 @@ summary code:hover {
 	margin: 0 0 1.25rem;
 	margin-bottom: 16px;
 	border-radius: 0.2rem;
-	max-width: 500px;
 }
 
 .fileinfo .fileinfo__header {
@@ -1108,7 +1107,8 @@ summary code:hover {
 	font-size: 1rem;
 	font-weight: 700;
 	display: flex;
-	flex-direction: column;
+	flex-direction: row;
+	flex: 1 0 auto;
 	justify-content: center;
 	align-items: stretch;
 	gap: 10px;
@@ -1118,6 +1118,14 @@ summary code:hover {
 .fileinfo .fileinfo__body .selection_row {
 	display: flex;
 	flex-direction: column;
+	flex-grow: 1;
+	align-items: start;
+}
+
+
+.fileinfo .fileinfo__body .download_row {
+	margin-top: 10px;
+	flex-grow: 1;
 }
 
 .fileinfo .fileinfo__body .selection_row .selection_block {
@@ -1135,8 +1143,9 @@ summary code:hover {
 
 .fileinfo .fileinfo__body .selection_row .selection_block .select2 {
 	flex-grow: 1;
-	max-width: 200px;
-	margin-left: auto;
+	width: 160px !important;
+	margin-left: 10px;
+	margin-right: auto;
 	text-align: left;
 	color: black;
 }
@@ -1299,6 +1308,31 @@ summary code:hover {
 	}
 }
 
+@media screen and (max-width: 1332px) {
+	.filelist {
+		margin-left: 0px;
+		margin-right: auto;
+	}
+
+	.fileinfo {
+		max-width: 500px;
+	}
+
+	.fileinfo .fileinfo__body {
+		flex-direction: column;
+	}
+
+	.fileinfo .fileinfo__body .selection_row .selection_block .select2 {
+		margin-left: auto;
+		margin-right: 0px;
+		flex-grow: 0;
+	}
+
+	.fileinfo .fileinfo__body .selection_row {
+		align-items: normal;
+	}
+}
+
 @media screen and (max-width: 900px) {
 	.container--outer {
 		width: 100%;
@@ -1438,7 +1472,7 @@ summary code:hover {
 	}
 
 	.fileinfo .fileinfo__body .selection_row .selection_block .select2 {
-		width: 100% !important; /* Override the select2's inlined width styling so we can do responsive display better */ 
+		width: 80% !important; /* Override the select2's inlined width styling so we can do responsive display better */ 
 		margin-top: 4px;
 		margin-bottom: 4px;
 		margin-right: auto;

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1187,10 +1187,11 @@ summary code:hover {
 	display: none;
 	position: absolute;
 	background-color: #f1f1f1;
-	max-height: 180px;
 	width: 200px;
-	z-index: 1;
 	box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+	z-index: 1;
+	border-radius: 4px;
+	max-height: 180px;
 	overflow: scroll;
 	overflow-x: hidden;
 }
@@ -1199,19 +1200,19 @@ summary code:hover {
 	background-color: #e0c388;
 }
 
-/* Clickable list element inside the dropdown */
+/* Button inside the dropdown */
 .dropdown-content button {
 	color: black;
 	text-decoration: none;
 	display: block;
+	border-radius: 0;
 	border: none;
-	padding-left: 4px;
 	width: 100%;
 	text-align: left;
-	font-weight: normal;
+	border-radius: 4px;
 }
 
-/* Change color of dropdown list element on hover */
+/* Change color of dropdown button on hover */
 .dropdown-content button:hover {
 	background-color: #d2d2d2;
 }

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1108,17 +1108,14 @@ summary code:hover {
 	font-weight: 700;
 	display: flex;
 	flex-direction: row;
-	flex: 1 0 auto;
 	justify-content: center;
 	align-items: stretch;
-	gap: 10px;
 	gap: .625rem;
 }
 
 .fileinfo .fileinfo__body .selection_row {
 	display: flex;
 	flex-direction: column;
-	flex-grow: 1;
 	align-items: start;
 }
 
@@ -1308,7 +1305,7 @@ summary code:hover {
 	}
 }
 
-@media screen and (max-width: 1332px) {
+@media screen and (max-width: 1032px) {
 	.filelist {
 		margin-left: 0px;
 		margin-right: auto;

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1084,8 +1084,9 @@ summary code:hover {
 	text-align: center;
 	margin: 0 0 20px;
 	margin: 0 0 1.25rem;
-	margin-bottom: 5px;
+	margin-bottom: 16px;
 	border-radius: 0.2rem;
+	max-width: 500px;
 }
 
 .fileinfo .fileinfo__header {
@@ -1102,16 +1103,40 @@ summary code:hover {
 	font-size: 1rem;
 	font-weight: 700;
 	display: flex;
+	flex-direction: column;
 	justify-content: center;
 	align-items: stretch;
 	gap: 10px;
 	gap: .625rem;
 }
 
-.fileinfo .fileinfo__body a {
-	padding: 10px;
+.fileinfo .fileinfo__body .selection_row {
+	display: flex;
+	flex-direction: column;
+}
+
+.fileinfo .fileinfo__body .selection_row .selection_block {
+	margin: 10px 10px 0px 10px;
 	padding: .625rem;
-	align-items: center;
+	display: flex;
+	flex-direction: row;
+	align-items: stretch;
+	justify-content: center;
+	flex: 1 1 0px;
+	text-decoration: none;
+	border-radius: 0.2rem;
+	position: relative;
+}
+
+.fileinfo .fileinfo__body .selection_row .selection_block select{
+	max-width: 200px;
+	flex-grow: 1;
+	margin-left: auto;
+}
+
+.fileinfo .fileinfo__body a {
+	margin: 0px 10px 10px 10px;
+	padding: .625rem;
 	display: flex;
 	flex-direction: row;
 	align-items: stretch;
@@ -1121,7 +1146,8 @@ summary code:hover {
 	border-radius: 0.2rem;
 }
 
-.fileinfo__icon {
+.normal__font__weight {
+	font-weight: normal;
 }
 
 .fileinfo__content {
@@ -1130,10 +1156,6 @@ summary code:hover {
 	align-items: stretch;
 	justify-content: center;
 	flex: 1 1 0px;
-}
-
-.fileinfo__placeholder {
-	visibility: hidden;
 }
 
 .installer-version {
@@ -1378,6 +1400,19 @@ summary code:hover {
 	}
 }
 
+@media screen and (max-width: 460px) {
+	.fileinfo .fileinfo__body .selection_row .selection_block {
+		flex-direction: column;
+	}
+
+	.fileinfo .fileinfo__body .selection_row .selection_block select{
+		max-width: none;
+		margin-top: 4px;
+		margin-bottom: 4px;
+		margin-left: 0px;
+	}
+}
+
 .anchor-wrapper .anchor-icon {
     visibility: hidden;
 	display: inline-block;
@@ -1411,6 +1446,7 @@ a.anchor-wrapper:hover, a.anchor-wrapper:focus {
 	--color-border-badges-legacy: #53d8da;
 	--color-download: #e68c37;
 	--color-download-highlight: #e5b04c;
+	--color-selection-box-background: #b1b8be;
 	--color-box: #bdc7c7;
 	--color-outer: #bdc7c7;
 	--color-border: #aab0b3;

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1128,12 +1128,6 @@ summary code:hover {
 	position: relative;
 }
 
-.fileinfo .fileinfo__body .selection_row .selection_block select{
-	max-width: 200px;
-	flex-grow: 1;
-	margin-left: auto;
-}
-
 .fileinfo .fileinfo__body a {
 	margin: 0px 10px 10px 10px;
 	padding: .625rem;
@@ -1161,6 +1155,72 @@ summary code:hover {
 .installer-version {
 	font-family: monospace;
 }
+
+/* Modified custom dropdown element from: https://www.w3schools.com/howto/howto_js_dropdown.asp */
+/* The container <div> - needed to position the dropdown content */
+.dropdown {
+	position: relative;
+	margin-left: auto;
+	display: inline;
+}
+
+/* Dropdown Button */
+.dropbtn {
+	background-color: #efefef;
+	color: rgb(0, 0, 0);
+	text-align: left;
+	width: 200px;
+	font-size: 16px;
+	border-radius: 4px;
+	border: 1px rgb(146, 146, 146);
+	border-style: solid;
+	cursor: pointer;
+}
+
+/* Dropdown button on hover & focus */
+.dropbtn:hover, .dropbtn:focus {
+	background-color: #c5c5c5;
+}
+
+/* Dropdown Content (Hidden by Default) */
+.dropdown-content {
+	display: none;
+	position: absolute;
+	background-color: #f1f1f1;
+	width: 200px;
+	box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+	z-index: 1;
+	border-radius: 4px;
+	max-height: 180px;
+	overflow: scroll;
+	overflow-x: hidden;
+}
+
+.selectedOption {
+	background-color: #e0c388;
+}
+
+/* Button inside the dropdown */
+.dropdown-content button {
+	color: black;
+	text-decoration: none;
+	display: block;
+	border-radius: 0;
+	border: none;
+	width: 100%;
+	text-align: left;
+	border-radius: 4px;
+}
+
+/* Change color of dropdown button on hover */
+.dropdown-content button:hover {
+	background-color: #d2d2d2;
+}
+
+/* Show the dropdown menu (use JS to add this class to the .dropdown-content container when the user clicks on the dropdown button) */
+.show {
+	display: block;
+} 
 
 /* Badges */
 .badges {
@@ -1405,11 +1465,12 @@ summary code:hover {
 		flex-direction: column;
 	}
 
-	.fileinfo .fileinfo__body .selection_row .selection_block select{
-		max-width: none;
+	.fileinfo .fileinfo__body .selection_row .selection_block .dropdown {
+		max-width: fit-content;
 		margin-top: 4px;
 		margin-bottom: 4px;
-		margin-left: 0px;
+		margin-left: auto;
+		margin-right: auto;
 	}
 }
 

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1147,15 +1147,16 @@ summary code:hover {
 }
 
 .fileinfo .fileinfo__body a {
+	display: flex;
+	flex: 1 1 0px;
+	flex-direction: row;
 	margin: 0px 10px 10px 10px;
 	padding: .625rem;
-	display: flex;
-	flex-direction: row;
+	border-radius: 0.2rem;
 	align-items: stretch;
 	justify-content: center;
-	flex: 1 1 0px;
 	text-decoration: none;
-	border-radius: 0.2rem;
+	text-shadow: var(--text-shadow-download);
 }
 
 .normal__font__weight {
@@ -1474,6 +1475,7 @@ a.anchor-wrapper:hover, a.anchor-wrapper:focus {
 	--color-footer-link-text: #bdc7c7;
 	--color-ends-background: #323232;
 	--color-meta-caption: #666666;
+	--text-shadow-download: none;
 	.footer_modetoggle-dark {
 		display: none;
 	}
@@ -1488,8 +1490,8 @@ a.anchor-wrapper:hover, a.anchor-wrapper:focus {
 	--color-border-badges-new: #8b5460;
 	--color-border-badges-legacy: #227778;
 	--color-background: #222427;
-	--color-download: #9d4405;
-	--color-download-highlight: #e68c37;
+	--color-download: #a94e0d;
+	--color-download-highlight: #d88231;
 	--color-box: #2e3135;
 	--color-outer: #111111;
 	--color-border: #5a5a5a;
@@ -1505,6 +1507,7 @@ a.anchor-wrapper:hover, a.anchor-wrapper:focus {
 	--color-footer-link-text: #bdc7c7;
 	--color-ends-background: #222222;
 	--color-meta-caption: #aab0b3;
+	--text-shadow-download: 0px 0px 2px black;
 	.footer_modetoggle-light {
 		display: none;
 	}

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1117,6 +1117,8 @@ summary code:hover {
 	display: flex;
 	flex-direction: column;
 	align-items: start;
+	margin-top: 10px;
+	flex-grow: 1;
 }
 
 
@@ -1126,7 +1128,7 @@ summary code:hover {
 }
 
 .fileinfo .fileinfo__body .selection_row .selection_block {
-	margin: 5px 10px 5px 10px;
+	margin: 0px 10px 10px 10px;
 	padding: .625rem;
 	display: flex;
 	flex-direction: row;

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1129,11 +1129,11 @@ summary code:hover {
 }
 
 .fileinfo .fileinfo__body .selection_row .selection_block {
-	margin: 10px 10px 0px 10px;
+	margin: 5px 10px 5px 10px;
 	padding: .625rem;
 	display: flex;
 	flex-direction: row;
-	align-items: stretch;
+	align-items: center;
 	justify-content: center;
 	flex: 1 1 0px;
 	text-decoration: none;
@@ -1330,6 +1330,10 @@ summary code:hover {
 
 	.fileinfo .fileinfo__body .selection_row {
 		align-items: normal;
+	}
+
+	.fileinfo .fileinfo__body .download_row {
+		margin-top: 0px;
 	}
 }
 

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1128,10 +1128,11 @@ summary code:hover {
 	position: relative;
 }
 
-.fileinfo .fileinfo__body .selection_row .selection_block select{
-	max-width: 200px;
+.fileinfo .fileinfo__body .selection_row .selection_block .select2 {
 	flex-grow: 1;
+	max-width: 200px;
 	margin-left: auto;
+	text-align: left;
 }
 
 .fileinfo .fileinfo__body a {
@@ -1405,11 +1406,11 @@ summary code:hover {
 		flex-direction: column;
 	}
 
-	.fileinfo .fileinfo__body .selection_row .selection_block select{
-		max-width: none;
+	.fileinfo .fileinfo__body .selection_row .selection_block .select2 {
+		width: 100% !important; /* Override the select2's inlined width styling so we can do responsive display better */ 
 		margin-top: 4px;
 		margin-bottom: 4px;
-		margin-left: 0px;
+		margin-right: auto;
 	}
 }
 

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1187,11 +1187,10 @@ summary code:hover {
 	display: none;
 	position: absolute;
 	background-color: #f1f1f1;
-	width: 200px;
-	box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-	z-index: 1;
-	border-radius: 4px;
 	max-height: 180px;
+	width: 200px;
+	z-index: 1;
+	box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
 	overflow: scroll;
 	overflow-x: hidden;
 }
@@ -1200,19 +1199,19 @@ summary code:hover {
 	background-color: #e0c388;
 }
 
-/* Button inside the dropdown */
+/* Clickable list element inside the dropdown */
 .dropdown-content button {
 	color: black;
 	text-decoration: none;
 	display: block;
-	border-radius: 0;
 	border: none;
+	padding-left: 4px;
 	width: 100%;
 	text-align: left;
-	border-radius: 4px;
+	font-weight: normal;
 }
 
-/* Change color of dropdown button on hover */
+/* Change color of dropdown list element on hover */
 .dropdown-content button:hover {
 	background-color: #d2d2d2;
 }

--- a/themes/mainroad/layouts/partials/colors.css
+++ b/themes/mainroad/layouts/partials/colors.css
@@ -372,6 +372,11 @@ details:hover {
 	background-color: var(--color-box);
 }
 
+.fileinfo .fileinfo__body .selection_row .selection_block {
+	background-color: var(--color-selection-box-background);
+	color: var(--color-text);
+}
+
 .fileinfo .fileinfo__body a {
 	background-color: var(--color-download);
 	color: var(--color-text);


### PR DESCRIPTION
Reduce the need for people to have to click twice to go to the project page. Instead, we allow them to download any version of NeoForge directly from the main site. It should be much more user friendly now.

![image](https://github.com/user-attachments/assets/ed80afba-125a-44a2-b851-6adea943192b)

When latest version of NeoForge is selected, the changelog button will automatically be /changelog url. Otherwise it will do the raw text page changelogs.

No beta tag is shown because the NeoForge versions already include beta in the name.

------------------
Preview URL: https://pr-74.neoforged-website-previews.pages.dev