### PR TITLE
Attempt to fix Chrome bookmark icons

### DIFF
--- a/themes/mainroad/layouts/_default/baseof.html
+++ b/themes/mainroad/layouts/_default/baseof.html
@@ -37,6 +37,9 @@
 	{{- end }}
 
 	<link rel="shortcut icon" href="{{ "favicon.ico" | relURL }}">
+	<link rel="icon" href="{{ "favicon.ico" | relURL }}" type="image/x-icon" /> 
+	<link rel="icon" href="https://neoforged.net/img/authors/neoforged.png" sizes="128x128" type="image/png"/>
+
 	<script src="{{ "js/modetoggle.js" | relURL }}"></script>
 </head>
 <body class="body">


### PR DESCRIPTION
Closes https://github.com/neoforged/websites/issues/37

I am hoping the presence of the png icon will make chrome grab that for the bookmark instead of img/authors.matyrobbrt.png image. It is very... odd

------------------
Preview URL: https://pr-76.neoforged-website-previews.pages.dev