### PR TITLE
Change the URL of jquery.min.js from googleapis to jsdelivr

### DIFF
--- a/layouts/shortcodes/files.html
+++ b/layouts/shortcodes/files.html
@@ -1,4 +1,4 @@
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
 <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 {{ if not ( .Page.Scratch.Get "nfJS") }}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1610a4b2-d3c0-4afe-a7f4-e8506f2837bc)

![image](https://github.com/user-attachments/assets/318800d0-4fb5-477b-b748-ef6b1866a57f)

In mainland China, due to the blocking of `ajax.googleapis.com` by the Great Firewall (GFW), users experience long loading times when visiting `neoforged.net`. The browser spends significant time waiting for responses from `ajax.googleapis.com`, which inevitably time out, severely slowing down the website's loading process. Replacing these resources with links from jsDelivr can effectively mitigate this issue.