### PR TITLE
Remove transitions on all elements

### DIFF
--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -9,7 +9,6 @@
 *::before,
 *::after {
 	box-sizing: border-box;
-	transition: all 0.5s;
 }
 
 article,


### PR DESCRIPTION
This PR removes the `transition` applied added to all elements by [a previous PR](https://github.com/neoforged/websites/pull/34/files#diff-708bc4f09b23c4c9aef008096d1e83101cf8a54abe53477f24ff66bab43dd0aeR12). While it is indeed cool and neat, as we've come to discover it causes different custom elements to jump around uncontrollably (especially those from vuetify - see [this discord message](https://discord.com/channels/313125603924639766/852298000042164244/1389981057109065840) and the one below) and also makes pages like the mod generator and the main page feel laggy.

------------------
Preview URL: https://pr-87.neoforged-website-previews.pages.dev